### PR TITLE
Add --gdbserver-wait to halt before first opcode

### DIFF
--- a/fuse.c
+++ b/fuse.c
@@ -402,10 +402,17 @@ int fuse_init(int argc, char **argv)
   if( do_start_files( &start_files ) ) return 1;
 
   gdbserver_init();
-  
+
+  if( settings_current.gdbserver_wait && !settings_current.gdbserver_enable )
+    ui_error( UI_ERROR_WARNING,
+              "--gdbserver-wait has no effect without --gdbserver-enable; ignoring it" );
+
   if (!settings_current.gdbserver_enable) {
     /* Must do this after all subsytems are initialised */
     debugger_command_evaluate( settings_current.debugger_command );
+  } else if( settings_current.gdbserver_wait ) {
+    /* Halt before the first opcode. */
+    debugger_mode = DEBUGGER_MODE_HALTED;
   }
 
   if( ui_mouse_present ) ui_mouse_grabbed = ui_mouse_grab( 1 );

--- a/settings-win32.pl
+++ b/settings-win32.pl
@@ -30,6 +30,8 @@ sub hashline ($) { '#line ', $_[0] + 1, '"', __FILE__, "\"\n" }
 
 my %options;
 
+my %command_line_only = ( 'gdbserver_wait' => 1 );
+
 while(<>) {
 
     next if /^\s*$/;
@@ -217,6 +219,8 @@ foreach my $name ( sort keys %options ) {
 
     my $type = $options{$name}->{type};
 
+    next if $command_line_only{$name};
+
     if( $type eq 'boolean' or $type eq 'numeric' ) {
 
 	print << "CODE";
@@ -290,6 +294,8 @@ CODE
 foreach my $name ( sort keys %options ) {
 
     my $type = $options{$name}->{type};
+
+    next if $command_line_only{$name};
 
     if( $type eq 'boolean' ) {
 
@@ -395,6 +401,8 @@ settings_var( settings_info *settings, unsigned char *name, unsigned char *last,
 CODE
 my %type = ('null' => 0, 'nsarray' => 0, 'boolean' => 1, 'numeric' => 1, 'string' => 2 );
 foreach my $name ( sort keys %options ) {
+    next if $command_line_only{$name};
+
     my $len = length $options{$name}->{configfile};
 
     print << "CODE";
@@ -519,6 +527,8 @@ foreach my $name ( sort keys %options ) {
 
     my $type = $options{$name}->{type};
     my $len = length "$options{$name}->{configfile}";
+
+    next if $command_line_only{$name};
 
     if( $type eq 'boolean' ) {
 

--- a/settings.dat
+++ b/settings.dat
@@ -92,6 +92,7 @@ covox, boolean, 0
 phantom_typist_mode, string, "Auto"
 gdbserver_enable, boolean, 0
 gdbserver_port, numeric, 1337
+gdbserver_wait, boolean, 0
 
 sound_device, string, NULL,, 'd'
 sound, boolean, 1

--- a/settings.pl
+++ b/settings.pl
@@ -35,6 +35,9 @@ my %fileAssoc = ( 'snapshot' => 1, 'tape_file' => 1, 'record_file' => 1,
                   'zxatasp_master_file' => 1, 'zxatasp_slave_file' => 1,
                   'zxcf_pri_file' => 1,
                   'plus3disk_file' => 1, 'betadisk_file' => 1 );
+
+my %command_line_only = ( 'gdbserver_wait' => 1 );
+
 while(<>) {
 
     next if /^\s*$/;
@@ -158,6 +161,8 @@ foreach my $name ( sort keys %options ) {
 
     my $type = $options{$name}->{type};
 
+    next if $command_line_only{$name};
+
     if( $type eq 'boolean' ) {
 	print << "CODE";
   value = settings->$name ? YES : NO;
@@ -212,6 +217,8 @@ foreach my $name ( sort keys %options ) {
 
     my $type = $options{$name}->{type};
     my $funcn = $options{$name}->{funcn};
+
+    next if $command_line_only{$name};
 
     if( $type eq 'boolean' ) {
 
@@ -291,6 +298,8 @@ CODE
 foreach my $name ( sort keys %options ) {
 
     my $type = $options{$name}->{type};
+
+    next if $command_line_only{$name};
 
     if( $type eq 'boolean' ) {
 	print << "CODE";


### PR DESCRIPTION
Halting at the first instruction lets a connecting gdb client arm breakpoints before any emulated code runs, so early-code debugging is deterministic regardless of ROM fast-load.

The flag is command-line only and never written to saved settings, so a one-off debugging launch cannot wedge later launches.