### PR TITLE
Fix noisy startup diagnostics

### DIFF
--- a/fusepb/controllers/FuseController.m
+++ b/fusepb/controllers/FuseController.m
@@ -1325,7 +1325,6 @@ save_as_exit:
 
 - (void)ui_menu_activate_debugger:(NSNumber*)active
 {
-  printf("tag: %d\n", [debugger tag]);
   debuggerEnabled = [active boolValue];
 }
 

--- a/ui/cocoa/SDL_joystick/SDL_sysjoystick.c
+++ b/ui/cocoa/SDL_joystick/SDL_sysjoystick.c
@@ -545,10 +545,15 @@ HIDBuildDevice(io_object_t hidDevice)
                                               kCFAllocatorDefault,
                                               kNilOptions);
         if ((result == KERN_SUCCESS) && hidProperties) {
-            /* create device interface */
-            result = HIDCreateOpenDeviceInterface(hidDevice, pDevice);
-            if (kIOReturnSuccess == result) {
-                HIDGetDeviceInfo(hidDevice, hidProperties, pDevice);    /* hidDevice used to find parents in registry tree */
+            HIDGetDeviceInfo(hidDevice, hidProperties, pDevice);    /* hidDevice used to find parents in registry tree */
+
+            /* Open only joysticks; the system owns keyboards and mice. */
+            if (pDevice->usagePage == kHIDPage_GenericDesktop &&
+                (pDevice->usage == kHIDUsage_GD_Joystick ||
+                 pDevice->usage == kHIDUsage_GD_GamePad ||
+                 pDevice->usage == kHIDUsage_GD_MultiAxisController) &&
+                kIOReturnSuccess ==
+                    HIDCreateOpenDeviceInterface(hidDevice, pDevice)) {
                 HIDGetCollectionElements(hidProperties, pDevice);
             } else {
                 DisposePtr((Ptr) pDevice);
@@ -688,18 +693,6 @@ SDL_SYS_JoystickInit(void)
 /*		if (KERN_SUCCESS != result)
 			HIDReportErrorNum ("IOObjectRelease error with ioHIDDeviceObject.", result);
 */
-
-        /* Filter device list to non-keyboard/mouse stuff */
-        if ((device->usagePage != kHIDPage_GenericDesktop) ||
-            ((device->usage != kHIDUsage_GD_Joystick &&
-              device->usage != kHIDUsage_GD_GamePad &&
-              device->usage != kHIDUsage_GD_MultiAxisController))) {
-
-            /* release memory for the device */
-            HIDDisposeDevice(&device);
-            DisposePtr((Ptr) device);
-            continue;
-        }
 
         /* Add device to the end of the list */
         if (lastDevice)

--- a/ui/cocoa/SDL_joystick/SDL_sysjoystick.c
+++ b/ui/cocoa/SDL_joystick/SDL_sysjoystick.c
@@ -236,15 +236,11 @@ HIDCloseReleaseInterface(recDevice * pDevice)
         /* close the interface */
         result = (*(pDevice->interface))->close(pDevice->interface);
         if (kIOReturnNotOpen == result) {
-            /* do nothing as device was not opened, thus can't be closed */
+            result = kIOReturnSuccess;  /* never opened: nothing to close */
         } else if (kIOReturnSuccess != result)
             HIDReportErrorNum("Failed to close IOHIDDeviceInterface.",
                               result);
-        /* release the interface */
-        result = (*(pDevice->interface))->Release(pDevice->interface);
-        if (kIOReturnSuccess != result)
-            HIDReportErrorNum("Failed to release IOHIDDeviceInterface.",
-                              result);
+        (*(pDevice->interface))->Release(pDevice->interface);
         pDevice->interface = NULL;
     }
     return result;


### PR DESCRIPTION
Removes benign messages printed to the console at every launch:

- `Failed to release IOHIDDeviceInterface.` and `HIDCloseReleaseInterface failed when trying to dipose device.` — stop treating `Release()`'s refcount as an `IOReturn`.
- `Failed to open pDevice->interface via open.` — filter the HID scan to joysticks before opening.
- `tag: <n>` — drop a stray debug `printf`.