### PR TITLE
Build the libspectrum commit pinned by the submodule

### DIFF
--- a/.github/workflows/build_libspectrum_macos_sub.yml
+++ b/.github/workflows/build_libspectrum_macos_sub.yml
@@ -7,10 +7,6 @@ on:
       key:
         type: string
         required: true
-      libspectrum_ref:
-        type: string
-        required: false
-        default: master
       use_zlib:
         type: boolean
         required: false
@@ -37,8 +33,7 @@ jobs:
       run:
         shell: bash
     env:
-      LIBSPECTRUM_DIR: libspectrum
-      LIBSPECTRUM_GIT_URL: https://github.com/fuse-emulator/libspectrum
+      LIBSPECTRUM_DIR: 3rdparty/libspectrum
 
     steps:
       - name: (1) Prepare environment
@@ -47,21 +42,19 @@ jobs:
           pwd
           ls -la
 
-          echo "Libspectrum URL: $LIBSPECTRUM_GIT_URL"
-          echo "Libspectrum ref: ${{ inputs.libspectrum_ref }}"
-
           echo "Use lib zlib: ${{ inputs.use_zlib && 'yes' || 'no' }}"
           echo "Use lib bzip2: ${{ inputs.use_bzip2 && 'yes' || 'no' }}"
           echo "Use lib libgcrypt: ${{ inputs.use_libgcrypt && 'yes' || 'no' }}"
           echo "Use lib libaudiofile: no"
           echo "Use fake glib: ${{ inputs.use_fake_glib && 'yes' || 'no' }}"
 
-      - name: (2) Clone libspectrum source
-        run: |
-          git init "$LIBSPECTRUM_DIR"
-          git -C "$LIBSPECTRUM_DIR" remote add origin "$LIBSPECTRUM_GIT_URL"
-          git -C "$LIBSPECTRUM_DIR" fetch --depth 1 origin "${{ inputs.libspectrum_ref }}"
-          git -C "$LIBSPECTRUM_DIR" checkout FETCH_HEAD
+      - name: (1b) Check out Fuse
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: (2) Fetch libspectrum source
+        run: git submodule update --init "$LIBSPECTRUM_DIR"
 
       - name: (2b) Capture libspectrum commit SHA for cache key
         id: libspectrum-sha

--- a/.github/workflows/build_libspectrum_windows_sub.yml
+++ b/.github/workflows/build_libspectrum_windows_sub.yml
@@ -7,10 +7,10 @@ on:
       key:
         type: string
         required: true
-      libspectrum_ref:
+      fuse_ref:
         type: string
         required: false
-        default: master
+        default: ""
       use_zlib:
         type: boolean
         required: false
@@ -42,8 +42,7 @@ jobs:
       LDFLAGS: "-L/usr/local/i686-w64-mingw32/lib"
       PKG_CONFIG_LIBDIR: "/usr/local/i686-w64-mingw32/lib/pkgconfig:/usr/i686-w64-mingw32/sys-root/mingw/lib/pkgconfig"
       CYGWIN_LIBDIR: "/usr/i686-w64-mingw32/sys-root/mingw/bin/"
-      LIBSPECTRUM_DIR: libspectrum
-      LIBSPECTRUM_GIT_URL: https://github.com/fuse-emulator/libspectrum
+      LIBSPECTRUM_DIR: 3rdparty/libspectrum
 
     steps:
       - name: (1) Prepare environment
@@ -53,22 +52,22 @@ jobs:
           echo "Adjust autocrlf in git.."
           git config --global core.autocrlf input
 
-          echo "Libspectrum URL: $LIBSPECTRUM_GIT_URL"
-          echo "Libspectrum ref: ${{ inputs.libspectrum_ref }}"
-
           echo "Use lib zlib: ${{ inputs.use_zlib && 'yes' || 'no' }}"
           echo "Use lib bzip2: ${{ inputs.use_bzip2 && 'yes' || 'no' }}"
           echo "Use lib libgcrypt: ${{ inputs.use_libgcrypt && 'yes' || 'no' }}"
           echo "Use lib libaudiofile: ${{ inputs.use_libaudiofile && 'yes' || 'no' }}"
 
-      - name: (2) Clone libspectrum source
+      - name: (1b) Check out Fuse
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.fuse_ref }}
+          persist-credentials: false
+
+      - name: (2) Fetch libspectrum source
         run: |
           cd ${GITHUB_WORKSPACE}
 
-          git init "$LIBSPECTRUM_DIR"
-          git -C "$LIBSPECTRUM_DIR" remote add origin "$LIBSPECTRUM_GIT_URL"
-          git -C "$LIBSPECTRUM_DIR" fetch --depth 1 origin "${{ inputs.libspectrum_ref }}"
-          git -C "$LIBSPECTRUM_DIR" checkout FETCH_HEAD
+          git submodule update --init "$LIBSPECTRUM_DIR"
 
       - name: (2b) Resolve Cygwin package cache path
         id: cygwin-cache-path

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -6,9 +6,8 @@ on: [pull_request]
 
 jobs:
   libspectrum:
-    # Build libspectrum from the canonical SourceForge repository.
+    # Build the libspectrum commit pinned by the 3rdparty/libspectrum submodule.
     name: "Libspectrum lib (MacOS)"
     uses: ./.github/workflows/build_libspectrum_macos_sub.yml
     with:
       key: fuse-app
-      libspectrum_ref: master

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -6,9 +6,8 @@ on: [pull_request]
 
 jobs:
   libspectrum:
-    # Build libspectrum from the canonical SourceForge repository.
+    # Build the libspectrum commit pinned by the 3rdparty/libspectrum submodule.
     name: "Libspectrum lib (Windows)"
     uses: ./.github/workflows/build_libspectrum_windows_sub.yml
     with:
       key: fuse-app
-      libspectrum_ref: master

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -20,11 +20,6 @@ on:
         required: false
         default: false
         description: "Indicates if release notes should be automatically generated"
-      libspectrum_branch:
-        type: string
-        required: true
-        default: "master"
-        description: "Libspectrum's branch to use"
       add_date_time:
         type: boolean
         required: false
@@ -53,11 +48,6 @@ on:
         required: false
         default: false
         description: "Indicates if release notes should be automatically generated"
-      libspectrum_branch:
-        type: string
-        required: false
-        default: "master"
-        description: "Libspectrum's branch to use"
       add_date_time:
         type: boolean
         required: false
@@ -79,12 +69,11 @@ jobs:
   ########################################
 
   libspectrum-windows:
-    # Build libspectrum from the canonical SourceForge repository.
+    # Build the libspectrum commit pinned by the 3rdparty/libspectrum submodule.
     name: "Libspectrum lib"
     uses: ./.github/workflows/build_libspectrum_windows_sub.yml
     with:
       key: fuse-app
-      libspectrum_ref: ${{ inputs.libspectrum_branch }}
 
   ########################################
   ### Make Testing builds for Windows  ###

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -8,57 +8,19 @@ on:
         type: string
         required: false
         default: ""
-        description: Fuse ref to build (branch, tag, or commit). Leave empty to use the selected workflow revision.
-      libspectrum_ref:
-        type: string
-        required: false
-        default: ""
-        description: Libspectrum ref to build (branch, tag, or commit). Leave empty to use master from the canonical SourceForge repository.
+        description: Fuse ref to build (branch, tag, or commit); also selects the libspectrum pin. Leave empty to use the selected workflow revision.
 
 jobs:
-  resolve-refs:
-    name: "Resolve source refs"
-    runs-on: ubuntu-latest
-    outputs:
-      fuse_ref: ${{ steps.resolve.outputs.fuse_ref }}
-      libspectrum_ref: ${{ steps.resolve.outputs.libspectrum_ref }}
-    steps:
-      - name: Resolve selected refs
-        id: resolve
-        run: |
-          if [ -n "${{ inputs.fuse_ref }}" ]; then
-            fuse_ref="${{ inputs.fuse_ref }}"
-          else
-            fuse_ref=""
-          fi
-
-          if [ -n "${{ inputs.libspectrum_ref }}" ]; then
-            libspectrum_ref="${{ inputs.libspectrum_ref }}"
-          else
-            libspectrum_ref="master"
-          fi
-
-          if [ -n "$fuse_ref" ]; then
-            echo "Fuse ref: ${fuse_ref}"
-          else
-            echo "Fuse ref: current workflow revision (${{ github.sha }})"
-          fi
-          echo "Libspectrum ref: ${libspectrum_ref}"
-
-          echo "fuse_ref=${fuse_ref}" >> "$GITHUB_OUTPUT"
-          echo "libspectrum_ref=${libspectrum_ref}" >> "$GITHUB_OUTPUT"
-
   libspectrum:
     name: "Libspectrum (Windows)"
-    needs: [resolve-refs]
     uses: ./.github/workflows/build_libspectrum_windows_sub.yml
     with:
       key: fuse-app
-      libspectrum_ref: ${{ needs.resolve-refs.outputs.libspectrum_ref }}
+      fuse_ref: ${{ inputs.fuse_ref }}
 
   fuse:
     name: "${{ matrix.build.name }}"
-    needs: [resolve-refs, libspectrum]
+    needs: [libspectrum]
     strategy:
       fail-fast: false
       matrix:
@@ -90,7 +52,7 @@ jobs:
     uses: ./.github/workflows/build_windows_sub.yml
     with:
       key: ${{ matrix.build.key }}
-      fuse_ref: ${{ needs.resolve-refs.outputs.fuse_ref }}
+      fuse_ref: ${{ inputs.fuse_ref }}
       dependencies: ${{ matrix.build.dependencies }}
       configure_params: ${{ matrix.build.configure_params }}
       verify_ui: ${{ matrix.build.verify_ui }}


### PR DESCRIPTION
CI built libspectrum from upstream `master` instead of the commit pinned in `3rdparty/libspectrum` — the one that ships in the binary. An upstream update incompatible with this fork broke the build ([example](https://github.com/speccytools/fusex/pull/67#issuecomment-5224981812)).

https://github.com/speccytools/fusex/blob/a3728dda3aed0a4a22eb09f6672adf50534de2b6/.github/workflows/build_libspectrum_macos_sub.yml#L10-L13 https://github.com/speccytools/fusex/blob/a3728dda3aed0a4a22eb09f6672adf50534de2b6/.github/workflows/build_libspectrum_macos_sub.yml#L39-L41

Both libspectrum jobs now run `git submodule update --init 3rdparty/libspectrum`, so CI builds what we ship. The hardcoded clone URL and the unused `libspectrum_ref` override go with it.
