### PR TITLE
Gate the Spectranet page commands behind BUILD_SPECTRANET

### DIFF
--- a/debugger/gdbserver_remote_commands.c
+++ b/debugger/gdbserver_remote_commands.c
@@ -137,6 +137,7 @@ static uint8_t remote_command_spectranet_info( const char *args GCC_UNUSED )
     return 0;
 }
 
+#ifdef BUILD_SPECTRANET
 static uint8_t
 remote_command_spectranet_set_page( const char *args )
 {
@@ -213,7 +214,6 @@ usage:
     return 1;
 }
 
-#ifdef BUILD_SPECTRANET
 static uint8_t remote_command_xfs_debug( const char *args )
 {
     int enable;
@@ -273,9 +273,9 @@ const struct remote_command_entry_t remote_commands[] = {
     { "reset", remote_command_reset },
     { "dump", remote_command_dump },
     { "spectranet-info", remote_command_spectranet_info },
+#ifdef BUILD_SPECTRANET
     { "spectranet-set-page", remote_command_spectranet_set_page },
     { "spectranet-set-pagein", remote_command_spectranet_set_pagein },
-#ifdef BUILD_SPECTRANET
     { "xfs-debug", remote_command_xfs_debug },
 #endif
     { NULL, NULL }


### PR DESCRIPTION
https://github.com/speccytools/fusex/pull/70 added the gdbserver remote commands `spectranet-set-page` and `spectranet-set-pagein` to `gdbserver_remote_commands.c`, which compiles regardless of `BUILD_SPECTRANET`. `spectranet-set-page` calls `spectranet_map_page()`, whose definition sits inside `#ifdef BUILD_SPECTRANET` in `spectranet.c` with no counterpart in the `!BUILD_SPECTRANET` stub block — so any Spectranet-off build (e.g. `--without-pthread`) fails to link:

```
gdbserver_remote_commands.c: undefined reference to `spectranet_map_page'
```

Fix: guard the two commands and their `remote_commands[]` entries with `#ifdef BUILD_SPECTRANET`, merged into the adjacent `xfs-debug` guard, so they are absent when Spectranet isn't built.