### PR TITLE
Fix RZX open failing with "not enough data in buffer"

### DIFF
--- a/fusepb/controllers/FuseController.m
+++ b/fusepb/controllers/FuseController.m
@@ -2164,7 +2164,7 @@ save_as_exit:
 - (void)openFile:(const char *)filename
 {
   char *snapshot;
-  utils_file file = {}; libspectrum_id_t type;
+  __block utils_file file = {}; libspectrum_id_t type;
   libspectrum_class_t lsclass;
   libspectrum_error libspec_error;
   libspectrum_snap* snap;


### PR DESCRIPTION
Opening an RZX file via the Open dialog fails with `libspectrum: rzx_read_header: not enough data in buffer`.

The `utils_file` struct on the stack is captured by value inside the `AppSandboxFileAccess` block, so `utils_read_file` populates a block-internal copy that is discarded when the block returns. The original struct stays zeroed (`buffer = NULL`, `length = 0`), and `libspectrum_rzx_read` receives an empty buffer. Declaring the variable `__block` makes the block capture it by reference.