### PR TITLE
Allow building without socket support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -790,6 +790,25 @@ case "$host_os" in
 esac
 fi
 AM_CONDITIONAL(HAVE_SOCKETS, test "$sockets" = yes)
+
+dnl See if the GDB server is requested
+AC_MSG_CHECKING([whether GDB server support requested])
+AC_ARG_ENABLE(gdbserver,
+AS_HELP_STRING([--disable-gdbserver], [do not build the GDB server]),
+if test "$enableval" = yes; then gdbserver=yes; else gdbserver=no; fi,
+gdbserver=yes)
+if test "$sockets" != yes; then
+  if test "$gdbserver" = yes; then
+    AC_MSG_WARN([GDB server support disabled because sockets are unavailable])
+  fi
+  gdbserver=no
+fi
+AC_MSG_RESULT($gdbserver)
+AM_CONDITIONAL(BUILD_GDBSERVER, test "$gdbserver" = yes)
+if test "$gdbserver" = yes; then
+  AC_DEFINE([BUILD_GDBSERVER], 1, [Defined if we support the GDB server])
+fi
+
 if test "$sockets" = yes; then
   build_ttx2000s=yes
   AC_DEFINE([BUILD_TTX2000S], 1, [Defined if we support ttx2000s])
@@ -1069,6 +1088,7 @@ echo "libxml2 support: ${libxml2}"
 echo "libpng support: ${libpng}"
 echo "Available audio drivers: ${audio_driver_list}"
 echo "Selected audio driver: ${audio_driver}"
+echo "GDB server support: ${gdbserver}"
 echo "Spectranet support: ${build_spectranet}"
 echo "SpeccyBoot support: ${linux_tap:-no}"
 echo "TTX2000 S support: ${build_ttx2000s}"

--- a/debugger/Makefile.am
+++ b/debugger/Makefile.am
@@ -29,17 +29,23 @@ fuse_SOURCES += \
                 debugger/disassemble.c \
                 debugger/event.c \
                 debugger/expression.c \
+                debugger/system_variable.c \
+                debugger/variable.c
+
+if BUILD_GDBSERVER
+fuse_SOURCES += \
                 debugger/gdbserver.c \
                 debugger/gdbserver_remote_commands.c \
                 debugger/gdbserver_utils.c \
-                debugger/system_variable.c \
-                debugger/packets.c \
-                debugger/variable.c
+                debugger/packets.c
 
 if BUILD_SPECTRANET
 fuse_SOURCES += \
                 debugger/vfile.c \
                 debugger/vfile_ext.c
+endif
+else
+fuse_SOURCES += debugger/gdbserver_stub.c
 endif
 
 debugger/commandl.c: debugger/commandy.c
@@ -52,6 +58,8 @@ noinst_HEADERS += \
                   debugger/debugger_internals.h \
                   debugger/gdbserver.h \
                   debugger/gdbserver_remote_commands.h \
+                  debugger/gdbserver_utils.h \
+                  debugger/packets.h \
                   debugger/vfile.h \
                   debugger/vfile_ext.h
 

--- a/debugger/gdbserver_stub.c
+++ b/debugger/gdbserver_stub.c
@@ -1,0 +1,102 @@
+/* gdbserver_stub.c: Stubs for builds without the GDB server
+   Copyright (c) 2026 The FuseX authors
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+*/
+
+#include "config.h"
+
+#include "gdbserver.h"
+#include "settings.h"
+#include "ui/ui.h"
+
+void
+gdbserver_init( void )
+{
+  if( settings_current.gdbserver_enable ) {
+    ui_error( UI_ERROR_WARNING,
+              "GDB server support is not available in this build" );
+    settings_current.gdbserver_enable = 0;
+  }
+}
+
+int
+gdbserver_start( int port GCC_UNUSED )
+{
+  return 1;
+}
+
+void
+gdbserver_stop( void )
+{
+}
+
+int
+gdbserver_activate( void )
+{
+  return 0;
+}
+
+int
+gdbserver_activate_with_reason( int trap_reason GCC_UNUSED )
+{
+  return 0;
+}
+
+void
+gdbserver_note_emulating( void )
+{
+}
+
+void
+gdbserver_refresh_status( void )
+{
+  settings_current.gdbserver_enable = 0;
+}
+
+void
+gdbserver_schedule_reset( void )
+{
+}
+
+void
+gdbserver_schedule_autoboot( void )
+{
+}
+
+void
+gdbserver_send_remote_console_output( const char *text GCC_UNUSED )
+{
+}
+
+uint8_t
+gdbserver_reset_via_remote_command( void )
+{
+  return 0;
+}
+
+void
+gdbserver_lock_network_write( void )
+{
+}
+
+void
+gdbserver_unlock_network_write( void )
+{
+}
+
+uint8_t
+gdbserver_execute_on_main_thread( trapped_action_t call GCC_UNUSED,
+                                  const void *data GCC_UNUSED,
+                                  void *response GCC_UNUSED )
+{
+  return 0;
+}
+
+void
+gdbserver_on_machine_reset( void )
+{
+}

--- a/utils.c
+++ b/utils.c
@@ -538,8 +538,12 @@ utils_save_binary( libspectrum_word start, size_t length,
 void
 utils_networking_init( void )
 {
+#ifdef HAVE_SOCKETS
+
   if( !networking_init_count )
     compat_socket_networking_init();
+
+#endif
 
   networking_init_count++;
 }
@@ -549,7 +553,10 @@ utils_networking_end( void )
 {
   networking_init_count--;
 
+#ifdef HAVE_SOCKETS
+
   if( !networking_init_count )
     compat_socket_networking_end();
-}
 
+#endif
+}


### PR DESCRIPTION
`--disable-sockets` excludes `compat/unix/socket.c` or its Win32 counterpart through `HAVE_SOCKETS`, but FuseX added unconditional socket consumers after inheriting that configure option: `debugger/Makefile.am` always builds the GDB RSP server and `utils_networking_init()` and `utils_networking_end()` always call the compatibility layer. A socket-free build therefore reaches the linker with undefined `compat_socket_close`, `compat_socket_networking_init`, and `compat_socket_networking_end`.

This adds an independent `--disable-gdbserver` option, makes unavailable or disabled sockets imply it, selects no-op GDB server stubs for the core call sites, keeps the Spectranet-specific GDB `vFile` extension with the real server, and restores the upstream `HAVE_SOCKETS` guards in `utils.c`.

The two intended configurations were generated separately with the null UI:

```sh
./configure --with-null-ui --with-audio-driver=null --disable-gdbserver
./configure --with-null-ui --with-audio-driver=null --disable-sockets
```

Both compile the stub successfully and reach the final link without unresolved GDB server or `compat_socket_*` symbols. At this branch's head the final null-UI executable link still fails on the pre-existing undefined `ui_disk_write`, `ui_mdr_write`, `ui_menu_activate`, and `ui_tape_write` symbols. That is a separate defect in the null UI rather than in socket support, and it is fixed by follow-up work that is not part of this PR. The normal Cocoa app was also rebuilt and ad-hoc signed successfully with the GDB server enabled.
