### PR TITLE
Bring the GTK 3 UI up to date: dark style, header bar, menus on GMenu

### DIFF
--- a/menu.h
+++ b/menu.h
@@ -37,9 +37,10 @@
 #include <gtk/gtk.h>
 
 #define MENU_CALLBACK( name ) \
-  void name( GtkAction *gtk_action GCC_UNUSED, gpointer data GCC_UNUSED )
+  void name( GSimpleAction *gtk_action GCC_UNUSED, \
+             GVariant *parameter GCC_UNUSED, gpointer data GCC_UNUSED )
 #define MENU_CALLBACK_WITH_ACTION( name ) \
-  void name( GtkAction *gtk_action GCC_UNUSED, guint action )
+  void name( GSimpleAction *gtk_action GCC_UNUSED, guint action )
 
 #else			/* #ifdef UI_GTK */
 

--- a/menu_data.pl
+++ b/menu_data.pl
@@ -31,6 +31,8 @@ sub dump_widget ($);
 sub _dump_widget ($$);
 sub dump_gtk ($$);
 sub _dump_gtk ($$$$$);
+sub action_name ($);
+sub xml_escape ($);
 sub dump_win32 ($$);
 sub _dump_win32 ($$$$);
 
@@ -98,7 +100,7 @@ while(<>) {
     } elsif( $type eq 'Item' ) {
 
 	$entry->{function} = $function if $function;
-	$entry->{action} = $action if $action;
+	$entry->{action} = $action if defined $action && $action ne '';
 
     }
 
@@ -223,13 +225,15 @@ sub dump_gtk ($$) {
     print << "HEADERS";
 #include <gtk/gtk.h>
 
+#include "ui/gtk3/gtkinternals.h"
+
 HEADERS
 
     print "/* Bindings to callbacks with action */\n";
 
     _dump_gtk( 'callbacks', $menu, '', 'menu', '  ' );
 
-    print "GtkActionEntry gtkui_menu_data[] = {\n\n";
+    print "GActionEntry gtkui_menu_data[] = {\n\n";
 
     _dump_gtk( 'actions', $menu, '', 'menu', '  ' );
 
@@ -238,21 +242,33 @@ HEADERS
 };
 
 guint gtkui_menu_data_size = ARRAY_SIZE( gtkui_menu_data );
+
+/* The accelerator for each menu item which has one */
+gtkui_menu_accel gtkui_menu_accels[] = {
+
+CODE
+
+    _dump_gtk( 'accels', $menu, '', 'menu', '  ' );
+
+    print << "CODE";
+  { NULL, NULL }
+
+};
 CODE
 
  } elsif( $mode eq 'ui' ) {
 
     print << "XML";
 <?xml version="1.0" encoding="utf-8"?>
-<ui>
-  <menubar name='MainMenu'>
+<interface>
+  <menu id='MainMenu'>
 XML
 
     _dump_gtk( 'ui', $menu, '', 'menu', '    ' );
 
     print << "XML";
-  </menubar>
-</ui>
+  </menu>
+</interface>
 XML
 
   }
@@ -262,9 +278,19 @@ sub _dump_gtk ($$$$$) {
 
   my( $mode, $menu, $gtk_path, $cpath, $spaces ) = @_;
 
+  # GMenu has no separators: a run of items between two separators is a
+  # section instead
+  my $in_section = 0;
+
   foreach my $item ( @{ $menu->{submenu} } ) {
 
-    next if $item->{type} eq 'Separator' && $mode ne 'ui';
+    if( $item->{type} eq 'Separator' ) {
+      if( $mode eq 'ui' && $in_section ) {
+        print "$spaces</section>\n";
+        $in_section = 0;
+      }
+      next;
+    }
 
     #Remove toplevel accelerators
     my $name = $item->{name};
@@ -274,63 +300,88 @@ sub _dump_gtk ($$$$$) {
     my $action_name = $name;
     $action_name =~ s/_//;
     $action_name = $gtk_path . "/" . $action_name;
-    $action_name =~ s|/|_|g;
-    $action_name =~ s/_//;
-    $action_name = uc( cname( $action_name ) );
+    $action_name = action_name( $action_name );
 
     $name =~ s/_// if $gtk_path;
     my $new_cpath = "${cpath}_" . cname( $name );
     my $function;
     my $binded_function = $item->{function} || $new_cpath;
 
-    if( $item->{type} eq 'Item' && $item->{action} ) {
-      $function = $new_cpath;
+    if( $item->{type} eq 'Item' && defined $item->{action} ) {
+      # The binding needs a name of its own when the item has no callback
+      # of its own to name it after
+      $function = $binded_function eq $new_cpath ? "${new_cpath}_action"
+                                                 : $new_cpath;
     } else {
       $function = $binded_function;
     }
 
     if( $mode eq 'callbacks' ) {
-      if( $item->{type} eq 'Item' && $item->{action} ) {
+      if( $item->{type} eq 'Item' && defined $item->{action} ) {
         print "static MENU_CALLBACK( ", $function, " )\n{\n";
         print "  $binded_function( gtk_action, $item->{action} );\n}\n\n";
       }
     } elsif( $mode eq 'ui' ) {
+      if( !$in_section ) {
+        print "$spaces<section>\n";
+        $in_section = 1;
+      }
+      my $xml_label = xml_escape( $label );
       if( $item->{type} eq 'Item' ) {
-        print "$spaces<menuitem name='$name' action='$action_name'/>\n";
-      } elsif( $item->{type} eq 'Separator' ) {
-        print "$spaces<separator/>\n";
+        print "$spaces  <item>\n";
+        print "$spaces    <attribute name='label'>$xml_label</attribute>\n";
+        print "$spaces    <attribute name='action'>win.$action_name</attribute>\n";
+        print "$spaces  </item>\n";
       } else {
-        print "$spaces<menu name='", $name, "' action='", $action_name, "'>\n";
+        print "$spaces  <submenu>\n";
+        print "$spaces    <attribute name='label'>$xml_label</attribute>\n";
+      }
+    } elsif( $mode eq 'accels' ) {
+      if( $item->{type} eq 'Item' && $item->{hotkey} ) {
+        print "  { \"win.$action_name\", \"$item->{hotkey}\" },\n";
       }
     } else {
-      #action_name, stock_id, label
-      print "  { \"$action_name\", NULL, \"$label\", ";
-
-      #hotkey
-      if( $item->{hotkey} ) {
-        print "\"$item->{hotkey}\"";
-      } else {
-        print 'NULL';
-      }
-
-      #tooltip
-      print ", NULL, ";
-
-      #callback
+      # Branches are labels in the menu model and have no action of their own
       if( $item->{type} eq 'Item' ) {
-        print "G_CALLBACK( ", $function, " )";
-      } else {
-        print "NULL";
+        print "  { \"$action_name\", $function, NULL, NULL, NULL },\n";
       }
-
-      print " },\n";
     }
 
-    _dump_gtk( $mode, $item, "$gtk_path/$name", $new_cpath, $spaces . "  " )
+    _dump_gtk( $mode, $item, "$gtk_path/$name", $new_cpath,
+               $mode eq 'ui' ? $spaces . "    " : $spaces . "  " )
                if $item->{submenu};
 
-    print "$spaces</menu>\n" if $mode eq 'ui' && $item->{type} eq 'Branch';
+    if( $mode eq 'ui' && $item->{type} eq 'Branch' ) {
+      print "$spaces  </submenu>\n";
+    }
   }
+
+  print "$spaces</section>\n" if $mode eq 'ui' && $in_section;
+}
+
+# The name of the GAction for a menu item, derived from its path so that
+# ui_menu_item_set_active() can find it from the UI independent path
+sub action_name ($) {
+
+  my( $path ) = @_;
+
+  $path = lc $path;
+  $path =~ tr|/|-|;
+  $path =~ tr/a-z0-9-//cd;
+  $path =~ s/^-//;
+
+  return $path;
+}
+
+sub xml_escape ($) {
+
+  my( $text ) = @_;
+
+  $text =~ s/&/&amp;/g;
+  $text =~ s/</&lt;/g;
+  $text =~ s/>/&gt;/g;
+
+  return $text;
 }
 
 sub dump_win32 ($$) {

--- a/ui/gtk3/binary.c
+++ b/ui/gtk3/binary.c
@@ -155,9 +155,7 @@ create_shared_binary_dialog( struct binary_info *info, const char *title,
  * already specified a filename, then pops the dialog requesting start address
  * and length.
  */
-void
-menu_file_loadbinarydata( GtkAction *gtk_action GCC_UNUSED,
-                          gpointer data GCC_UNUSED )
+MENU_CALLBACK( menu_file_loadbinarydata )
 {
   int error;
 
@@ -304,9 +302,7 @@ load_data( GtkEntry *entry GCC_UNUSED, gpointer user_data )
  * the file selector if a selected file isn't already in the static structure,
  * then pops up the filename/start/length dialog.
  */
-void
-menu_file_savebinarydata( GtkAction *gtk_action GCC_UNUSED,
-                          gpointer data GCC_UNUSED )
+MENU_CALLBACK( menu_file_savebinarydata )
 {
   fuse_emulation_pause();
 

--- a/ui/gtk3/browse.c
+++ b/ui/gtk3/browse.c
@@ -67,9 +67,7 @@ enum
   NUM_COLS
 };
 
-void
-menu_media_tape_browse( GtkAction *gtk_action GCC_UNUSED,
-                        gpointer data GCC_UNUSED )
+MENU_CALLBACK( menu_media_tape_browse )
 {
   /* Firstly, stop emulation */
   fuse_emulation_pause();

--- a/ui/gtk3/debugger.c
+++ b/ui/gtk3/debugger.c
@@ -243,10 +243,17 @@ ui_debugger_activate( void )
   fuse_emulation_pause();
 
   /* Create the dialog box if it doesn't already exist */
-  if( !dialog_created ) if( create_dialog() ) return 1;
+  if( !dialog_created ) if( create_dialog() ) {
+    fuse_emulation_unpause();
+    return 1;
+  }
 
   gtk_widget_show_all( dialog );
-  error = hide_hidden_panes(); if( error ) return error;
+  error = hide_hidden_panes();
+  if( error ) {
+    fuse_emulation_unpause();
+    return error;
+  }
 
   gtk_widget_set_sensitive( continue_button, 1 );
   gtk_widget_set_sensitive( break_button, 0 );

--- a/ui/gtk3/debugger.c
+++ b/ui/gtk3/debugger.c
@@ -108,18 +108,23 @@ enum {
 
 static int create_dialog( void );
 static int hide_hidden_panes( void );
-static GtkCheckMenuItem* get_pane_menu_item( debugger_pane pane );
+static GAction* get_pane_action( debugger_pane pane );
 static GtkWidget* get_pane( debugger_pane pane );
-static int create_menu_bar( GtkBox *parent, GtkAccelGroup **accel_group );
-static void toggle_display( GtkToggleAction* action, debugger_pane pane );
-static void toggle_display_registers( GtkToggleAction* action, gpointer data );
-static void toggle_display_memory_map( GtkToggleAction* action, gpointer data );
-static void toggle_display_breakpoints( GtkToggleAction* action,
+static int create_menu_bar( GtkBox *parent );
+static void toggle_display( GSimpleAction *action, GVariant *state,
+                            debugger_pane pane );
+static void toggle_display_registers( GSimpleAction *action, GVariant *state,
+                                      gpointer data );
+static void toggle_display_memory_map( GSimpleAction *action, GVariant *state,
+                                       gpointer data );
+static void toggle_display_breakpoints( GSimpleAction *action, GVariant *state,
                                         gpointer data );
-static void toggle_display_disassembly( GtkToggleAction* action,
+static void toggle_display_disassembly( GSimpleAction *action, GVariant *state,
                                         gpointer data );
-static void toggle_display_stack( GtkToggleAction* action, gpointer data );
-static void toggle_display_events( GtkToggleAction* action, gpointer data );
+static void toggle_display_stack( GSimpleAction *action, GVariant *state,
+                                  gpointer data );
+static void toggle_display_events( GSimpleAction *action, GVariant *state,
+                                   gpointer data );
 static int create_register_display( GtkBox *parent, PangoFontDescription *font );
 static int create_memory_map( GtkBox *parent );
 static void create_breakpoints( GtkBox *parent );
@@ -190,36 +195,54 @@ static int dialog_created = 0;
 static int debugger_active;
 
 /* The UIManager used to create the menu bar */
-static GtkUIManager *ui_manager_debugger = NULL;
+static GSimpleActionGroup *debugger_actions = NULL;
 
 /* The debugger's menu bar */
-const gchar debugger_menu[] =
-"<menubar name='DebuggerMenu'>"
-"  <menu name='View' action='VIEW'>"
-"    <menuitem name='Registers' action='VIEW_REGISTERS'/>"
-"    <menuitem name='Memory Map' action='VIEW_MEMORY_MAP'/>"
-"    <menuitem name='Breakpoints' action='VIEW_BREAKPOINTS'/>"
-"    <menuitem name='Disassembly' action='VIEW_DISASSEMBLY'/>"
-"    <menuitem name='Stack' action='VIEW_STACK'/>"
-"    <menuitem name='Events' action='VIEW_EVENTS'/>"
+static const gchar debugger_menu[] =
+"<interface>"
+"  <menu id='DebuggerMenu'>"
+"    <submenu>"
+"      <attribute name='label'>_View</attribute>"
+"      <section>"
+"        <item>"
+"          <attribute name='label'>_Registers</attribute>"
+"          <attribute name='action'>debugger.registers</attribute>"
+"        </item>"
+"        <item>"
+"          <attribute name='label'>_Memory Map</attribute>"
+"          <attribute name='action'>debugger.memory-map</attribute>"
+"        </item>"
+"        <item>"
+"          <attribute name='label'>_Breakpoints</attribute>"
+"          <attribute name='action'>debugger.breakpoints</attribute>"
+"        </item>"
+"        <item>"
+"          <attribute name='label'>_Disassembly</attribute>"
+"          <attribute name='action'>debugger.disassembly</attribute>"
+"        </item>"
+"        <item>"
+"          <attribute name='label'>_Stack</attribute>"
+"          <attribute name='action'>debugger.stack</attribute>"
+"        </item>"
+"        <item>"
+"          <attribute name='label'>_Events</attribute>"
+"          <attribute name='action'>debugger.events</attribute>"
+"        </item>"
+"      </section>"
+"    </submenu>"
 "  </menu>"
-"</menubar>";
+"</interface>";
 
-/* The debugger's menu actions */
-static GtkActionEntry menu_data[] = {
+/* The debugger's menu actions: one for each pane, holding whether that
+   pane is shown */
+static GActionEntry menu_data[] = {
 
-  { "VIEW", NULL, "_View", NULL, NULL, NULL },
-
-};
-
-static GtkToggleActionEntry menu_toggles[] = {
-
-  { "VIEW_REGISTERS", NULL, "_Registers", NULL, NULL, G_CALLBACK( toggle_display_registers ), TRUE },
-  { "VIEW_MEMORY_MAP", NULL, "_Memory Map", NULL, NULL, G_CALLBACK( toggle_display_memory_map ), TRUE },
-  { "VIEW_BREAKPOINTS", NULL, "_Breakpoints", NULL, NULL, G_CALLBACK( toggle_display_breakpoints ), TRUE },
-  { "VIEW_DISASSEMBLY", NULL, "_Disassembly", NULL, NULL, G_CALLBACK( toggle_display_disassembly ), TRUE },
-  { "VIEW_STACK", NULL, "_Stack", NULL, NULL, G_CALLBACK( toggle_display_stack ), TRUE },
-  { "VIEW_EVENTS", NULL, "_Events", NULL, NULL, G_CALLBACK( toggle_display_events ), TRUE },
+  { "registers", NULL, NULL, "true", toggle_display_registers },
+  { "memory-map", NULL, NULL, "true", toggle_display_memory_map },
+  { "breakpoints", NULL, NULL, "true", toggle_display_breakpoints },
+  { "disassembly", NULL, NULL, "true", toggle_display_disassembly },
+  { "stack", NULL, NULL, "true", toggle_display_stack },
+  { "events", NULL, NULL, "true", toggle_display_events },
 
 };
 
@@ -272,13 +295,19 @@ static int
 hide_hidden_panes( void )
 {
   debugger_pane i;
-  GtkCheckMenuItem *checkitem; GtkWidget *pane;
+  GAction *action; GtkWidget *pane;
+  GVariant *state;
+  int shown;
 
   for( i = DEBUGGER_PANE_BEGIN; i < DEBUGGER_PANE_END; i++ ) {
 
-    checkitem = get_pane_menu_item( i ); if( !checkitem ) return 1;
+    action = get_pane_action( i ); if( !action ) return 1;
 
-    if( gtk_check_menu_item_get_active( checkitem ) ) continue;
+    state = g_action_get_state( action );
+    shown = g_variant_get_boolean( state );
+    g_variant_unref( state );
+
+    if( shown ) continue;
 
     pane = get_pane( i ); if( !pane ) return 1;
 
@@ -288,41 +317,38 @@ hide_hidden_panes( void )
   return 0;
 }
 
-static GtkCheckMenuItem*
-get_pane_menu_item( debugger_pane pane )
+static GAction*
+get_pane_action( debugger_pane pane )
 {
-  const gchar *path;
-  GtkWidget *menu_item;
+  const gchar *name;
+  GAction *action;
 
-  path = NULL;
+  name = NULL;
 
   switch( pane ) {
-  case DEBUGGER_PANE_REGISTERS: path = "/View/Registers"; break;
-  case DEBUGGER_PANE_MEMORYMAP: path = "/View/Memory Map"; break;
-  case DEBUGGER_PANE_BREAKPOINTS: path = "/View/Breakpoints"; break;
-  case DEBUGGER_PANE_DISASSEMBLY: path = "/View/Disassembly"; break;
-  case DEBUGGER_PANE_STACK: path = "/View/Stack"; break;
-  case DEBUGGER_PANE_EVENTS: path = "/View/Events"; break;
+  case DEBUGGER_PANE_REGISTERS: name = "registers"; break;
+  case DEBUGGER_PANE_MEMORYMAP: name = "memory-map"; break;
+  case DEBUGGER_PANE_BREAKPOINTS: name = "breakpoints"; break;
+  case DEBUGGER_PANE_DISASSEMBLY: name = "disassembly"; break;
+  case DEBUGGER_PANE_STACK: name = "stack"; break;
+  case DEBUGGER_PANE_EVENTS: name = "events"; break;
 
   case DEBUGGER_PANE_END: break;
   }
 
-  if( !path ) {
+  if( !name ) {
     ui_error( UI_ERROR_ERROR, "unknown debugger pane %u", pane );
     return NULL;
   }
 
-  gchar *full_path = g_strdup_printf( "/DebuggerMenu%s", path );
-  menu_item = gtk_ui_manager_get_widget( ui_manager_debugger, full_path );
-  g_free( full_path );
+  action = g_action_map_lookup_action( G_ACTION_MAP( debugger_actions ), name );
 
-  if( !menu_item ) {
-    ui_error( UI_ERROR_ERROR, "couldn't get menu item '%s'",
-	      path );
+  if( !action ) {
+    ui_error( UI_ERROR_ERROR, "couldn't get menu item '%s'", name );
     return NULL;
   }
 
-  return GTK_CHECK_MENU_ITEM( menu_item );
+  return action;
 }
 
 static GtkWidget*
@@ -372,11 +398,14 @@ create_dialog( void )
   content_area = gtk_dialog_get_content_area( GTK_DIALOG( dialog ) );
 
   /* The menu bar */
-  error = create_menu_bar( GTK_BOX( content_area ), &accel_group );
+  error = create_menu_bar( GTK_BOX( content_area ) );
   if( error ) return error;
 
-  /* Keyboard shortcuts */
+  /* Keyboard shortcuts. The window takes its own reference to the
+     accelerator group and keeps it alive for us */
+  accel_group = gtk_accel_group_new();
   gtk_window_add_accel_group( GTK_WINDOW( dialog ), accel_group );
+  g_object_unref( accel_group );
 
   /* Some boxes to contain the things we want to display */
   hbox = gtk_box_new( GTK_ORIENTATION_HORIZONTAL, 0 );
@@ -415,54 +444,53 @@ create_dialog( void )
 }
 
 static int
-create_menu_bar( GtkBox *parent, GtkAccelGroup **accel_group )
+create_menu_bar( GtkBox *parent )
 {
-  GError *error = NULL;
-  GtkActionGroup *menu_action_group;
+  GtkBuilder *builder;
+  GMenuModel *model;
   GtkWidget *menu_bar;
-  guint ui_menu_id;
+  GError *error = NULL;
 
-  /* FIXME: we should unref this at some point */
-  ui_manager_debugger = gtk_ui_manager_new();
+  debugger_actions = g_simple_action_group_new();
+  g_action_map_add_action_entries( G_ACTION_MAP( debugger_actions ), menu_data,
+                                   ARRAY_SIZE( menu_data ), NULL );
 
-  /* Load actions */
-  menu_action_group = gtk_action_group_new( "DebuggerActionGroup" );
-  gtk_action_group_add_actions( menu_action_group, menu_data,
-				ARRAY_SIZE( menu_data ), NULL );
-  gtk_action_group_add_toggle_actions( menu_action_group, menu_toggles,
-                                       ARRAY_SIZE( menu_toggles ), NULL );
-  gtk_ui_manager_insert_action_group( ui_manager_debugger, menu_action_group,
-                                      0 );
-  g_object_unref( menu_action_group );
-
-  /* Load the menu */
-  ui_menu_id = gtk_ui_manager_add_ui_from_string( ui_manager_debugger,
-                                                  debugger_menu,
-                                                  sizeof( debugger_menu ),
-                                                  &error );
-  if( error ) {
+  builder = gtk_builder_new();
+  if( !gtk_builder_add_from_string( builder, debugger_menu, -1, &error ) ) {
+    ui_error( UI_ERROR_ERROR, "couldn't build the debugger menu: %s",
+	      error->message );
     g_error_free( error );
+    g_object_unref( builder );
     return 1;
   }
-  else if( !ui_menu_id ) return 1;
 
-  *accel_group = gtk_ui_manager_get_accel_group( ui_manager_debugger );
+  model = G_MENU_MODEL( gtk_builder_get_object( builder, "DebuggerMenu" ) );
+  if( !model ) {
+    ui_error( UI_ERROR_ERROR, "couldn't find the debugger menu" );
+    g_object_unref( builder );
+    return 1;
+  }
 
-  menu_bar = gtk_ui_manager_get_widget( ui_manager_debugger, "/DebuggerMenu" );
+  menu_bar = gtk_menu_bar_new_from_model( model );
+  gtk_widget_insert_action_group( menu_bar, "debugger",
+                                  G_ACTION_GROUP( debugger_actions ) );
+  g_object_unref( builder );
 
   gtk_box_pack_start( parent, menu_bar, FALSE, FALSE, 0 );
-  
+
   return 0;
 }
 
 static void
-toggle_display( GtkToggleAction* action, debugger_pane pane_id )
+toggle_display( GSimpleAction *action, GVariant *state, debugger_pane pane_id )
 {
   GtkWidget *pane;
 
+  g_simple_action_set_state( action, state );
+
   pane = get_pane( pane_id ); if( !pane ) return;
 
-  if( gtk_toggle_action_get_active( action ) ) {
+  if( g_variant_get_boolean( state ) ) {
     gtk_widget_show_all( pane );
   } else {
     gtk_widget_hide( pane );
@@ -470,39 +498,45 @@ toggle_display( GtkToggleAction* action, debugger_pane pane_id )
 }
 
 static void
-toggle_display_registers( GtkToggleAction* action, gpointer data GCC_UNUSED )
+toggle_display_registers( GSimpleAction *action, GVariant *state,
+                   gpointer data GCC_UNUSED )
 {
-  toggle_display( action, DEBUGGER_PANE_REGISTERS );
+  toggle_display( action, state, DEBUGGER_PANE_REGISTERS );
 }
 
 static void
-toggle_display_memory_map( GtkToggleAction* action, gpointer data GCC_UNUSED )
+toggle_display_memory_map( GSimpleAction *action, GVariant *state,
+                   gpointer data GCC_UNUSED )
 {
-  toggle_display( action, DEBUGGER_PANE_MEMORYMAP );
+  toggle_display( action, state, DEBUGGER_PANE_MEMORYMAP );
 }
 
 static void
-toggle_display_breakpoints( GtkToggleAction* action, gpointer data GCC_UNUSED )
+toggle_display_breakpoints( GSimpleAction *action, GVariant *state,
+                   gpointer data GCC_UNUSED )
 {
-  toggle_display( action, DEBUGGER_PANE_BREAKPOINTS );
+  toggle_display( action, state, DEBUGGER_PANE_BREAKPOINTS );
 }
 
 static void
-toggle_display_disassembly( GtkToggleAction* action, gpointer data GCC_UNUSED )
+toggle_display_disassembly( GSimpleAction *action, GVariant *state,
+                   gpointer data GCC_UNUSED )
 {
-  toggle_display( action, DEBUGGER_PANE_DISASSEMBLY );
+  toggle_display( action, state, DEBUGGER_PANE_DISASSEMBLY );
 }
 
 static void
-toggle_display_stack( GtkToggleAction* action, gpointer data GCC_UNUSED )
+toggle_display_stack( GSimpleAction *action, GVariant *state,
+                   gpointer data GCC_UNUSED )
 {
-  toggle_display( action, DEBUGGER_PANE_STACK );
+  toggle_display( action, state, DEBUGGER_PANE_STACK );
 }
 
 static void
-toggle_display_events( GtkToggleAction* action, gpointer data GCC_UNUSED )
+toggle_display_events( GSimpleAction *action, GVariant *state,
+                   gpointer data GCC_UNUSED )
 {
-  toggle_display( action, DEBUGGER_PANE_EVENTS );
+  toggle_display( action, state, DEBUGGER_PANE_EVENTS );
 }
 
 static int

--- a/ui/gtk3/filter_options.c
+++ b/ui/gtk3/filter_options.c
@@ -26,9 +26,7 @@ static GtkWidget
 
 static int dialog_created;  /* Have we created the dialog box yet? */
 
-void
-menu_options_filteroptions( GtkAction *gtk_action GCC_UNUSED,
-                        gpointer data GCC_UNUSED )
+MENU_CALLBACK( menu_options_filteroptions )
 {
   /* Firstly, stop emulation */
   fuse_emulation_pause();

--- a/ui/gtk3/gtkdisplay.c
+++ b/ui/gtk3/gtkdisplay.c
@@ -144,7 +144,8 @@ static void cancel_pending_resize( void );
 static gboolean gtkdisplay_draw( GtkWidget *widget, cairo_t *cr,
                                  gpointer user_data );
 
-static gint drawing_area_resize_callback( GtkWidget *widget, GdkEvent *event,
+static void drawing_area_resize_callback( GtkWidget *widget,
+                                          GtkAllocation *allocation,
                                           gpointer data );
 
 static int
@@ -212,7 +213,7 @@ uidisplay_init( int width, int height )
 
   colour_format = FORMAT_x8r8g8b8;
 
-  g_signal_connect( G_OBJECT( gtkui_window ), "configure_event",
+  g_signal_connect( G_OBJECT( gtkui_drawing_area ), "size-allocate",
                     G_CALLBACK( drawing_area_resize_callback ), NULL );
 
   error = init_colours( colour_format ); if( error ) return error;
@@ -728,24 +729,26 @@ drawing_area_resize_timeout( gpointer data GCC_UNUSED )
   return G_SOURCE_REMOVE;
 }
 
-/* Called by gtkui_window on "configure_event".
-   On GTK 3 the window determines the size of the drawing area.
+/* Called by gtkui_drawing_area on "size-allocate".
+   On GTK 3 the window determines the size of the drawing area, so take
+   the size from the drawing area itself: the window's own size can't be
+   used for this, as with client side decorations it also covers the
+   header bar and the invisible border drawn around the window.
 
    Wait for RESIZE_TIMEOUT_MS before changing the scaler to prevent
    the window from flickering while it is being resized. */
-static gint
-drawing_area_resize_callback( GtkWidget *widget GCC_UNUSED, GdkEvent *event,
+static void
+drawing_area_resize_callback( GtkWidget *widget GCC_UNUSED,
+                              GtkAllocation *allocation,
                               gpointer data GCC_UNUSED )
 {
-  pending_width  = event->configure.width;
-  pending_height = event->configure.height - extra_height;
+  pending_width  = allocation->width;
+  pending_height = allocation->height;
   resize_last_activity = g_get_monotonic_time();
 
   if( !resize_timeout_id )
     resize_timeout_id =
       g_timeout_add( RESIZE_TIMEOUT_MS, drawing_area_resize_timeout, NULL );
-
-  return FALSE;
 }
 
 void
@@ -763,8 +766,9 @@ gtkdisplay_update_geometry( void )
      don't set geometry of widgets. See [bugs:#344] */
   geometry_widget = NULL;
 
-  /* Add extra space for menu bar */
-  extra_height = gtkui_menubar_get_height();
+  /* The header bar is the window's titlebar: GTK adds its height to the
+     size asked for here, so only the status bar has to be accounted for */
+  extra_height = 0;
 
   /* Add extra space for status bar + padding */
   if( settings_current.statusbar ) {

--- a/ui/gtk3/gtkinternals.h
+++ b/ui/gtk3/gtkinternals.h
@@ -121,7 +121,6 @@ GtkWidget *gtkstock_dialog_new( const gchar *title, GCallback destroy );
 int gtkui_get_monospaced_font( PangoFontDescription **font );
 void gtkui_free_font( PangoFontDescription *font );
 
-int gtkui_menubar_get_height( void );
 
 /* Show/hide the menu bar and status bar */
 void gtkui_set_bars_visible( int visible );

--- a/ui/gtk3/gtkinternals.h
+++ b/ui/gtk3/gtkinternals.h
@@ -129,8 +129,15 @@ void gtkui_set_bars_visible( int visible );
  * The menu data (menu_data.c)
  */
 
-extern GtkActionEntry gtkui_menu_data[];
+/* The accelerator for one menu item, as generated from menu_data.dat */
+typedef struct gtkui_menu_accel {
+  const char *action;		/* eg "win.file-open" */
+  const char *accel;		/* eg "F3" */
+} gtkui_menu_accel;
+
+extern GActionEntry gtkui_menu_data[];
 extern guint gtkui_menu_data_size;
+extern gtkui_menu_accel gtkui_menu_accels[];
 
 /*
  * Resources for the GTK UI (ui/gtk3/resources.xml)

--- a/ui/gtk3/gtkjoystick.c
+++ b/ui/gtk3/gtkjoystick.c
@@ -183,8 +183,7 @@ create_joystick_options_store( void )
 }
 
 void
-menu_options_joysticks_select( GtkAction *gtk_action GCC_UNUSED,
-                               guint callback_action )
+menu_options_joysticks_select( GSimpleAction *gtk_action GCC_UNUSED, guint callback_action )
 {
   GtkWidget *dialog, *hbox, *vbox, *content_area;
   GtkTreeModel *model;

--- a/ui/gtk3/gtkui.c
+++ b/ui/gtk3/gtkui.c
@@ -26,6 +26,7 @@
 
 #include <math.h>
 #include <stdio.h>
+#include <string.h>
 
 #include <gdk/gdkkeysyms.h>
 #include <gtk/gtk.h>
@@ -158,6 +159,170 @@ static void gtkui_drag_data_received( GtkWidget *widget GCC_UNUSED,
   gtk_drag_finish( drag_context, success, FALSE, timestamp );
 }
 
+/* GTK 3 applications have to opt in to the dark variant of their theme, so
+   ask the desktop whether it prefers a dark style and keep
+   gtk-application-prefer-dark-theme in sync with the answer. The XDG
+   settings portal is the portable source for this; where it isn't running
+   we read the GNOME setting directly. */
+
+/* Values of the org.freedesktop.appearance color-scheme setting */
+#define COLOR_SCHEME_PREFER_DARK 1
+
+static GDBusProxy *settings_portal = NULL;
+static GSettings *interface_settings = NULL;
+
+static void
+gtkui_set_dark_theme( gboolean prefer_dark )
+{
+  GtkSettings *settings = gtk_settings_get_default();
+
+  if( settings )
+    g_object_set( settings, "gtk-application-prefer-dark-theme", prefer_dark,
+                  NULL );
+}
+
+static int
+gtkui_portal_read_color_scheme( guint32 *color_scheme )
+{
+  GVariant *reply, *value;
+  GError *error = NULL;
+  int error_code = 1;
+
+  reply = g_dbus_proxy_call_sync( settings_portal, "ReadOne",
+                                  g_variant_new( "(ss)",
+                                                 "org.freedesktop.appearance",
+                                                 "color-scheme" ),
+                                  G_DBUS_CALL_FLAGS_NONE, 1000, NULL, &error );
+
+  /* ReadOne is only in version 2 and later of the portal; earlier versions
+     have Read, which returns the value wrapped in a second variant */
+  if( !reply && g_error_matches( error, G_DBUS_ERROR,
+                                 G_DBUS_ERROR_UNKNOWN_METHOD ) ) {
+    g_clear_error( &error );
+    reply = g_dbus_proxy_call_sync( settings_portal, "Read",
+                                    g_variant_new( "(ss)",
+                                                   "org.freedesktop.appearance",
+                                                   "color-scheme" ),
+                                    G_DBUS_CALL_FLAGS_NONE, 1000, NULL,
+                                    &error );
+  }
+
+  if( !reply ) {
+    g_error_free( error );
+    return 1;
+  }
+
+  g_variant_get( reply, "(v)", &value );
+
+  while( g_variant_is_of_type( value, G_VARIANT_TYPE_VARIANT ) ) {
+    GVariant *inner = g_variant_get_variant( value );
+    g_variant_unref( value );
+    value = inner;
+  }
+
+  if( g_variant_is_of_type( value, G_VARIANT_TYPE_UINT32 ) ) {
+    *color_scheme = g_variant_get_uint32( value );
+    error_code = 0;
+  }
+
+  g_variant_unref( value );
+  g_variant_unref( reply );
+
+  return error_code;
+}
+
+static void
+gtkui_portal_signal( GDBusProxy *proxy GCC_UNUSED,
+                     gchar *sender_name GCC_UNUSED, gchar *signal_name,
+                     GVariant *parameters, gpointer data GCC_UNUSED )
+{
+  const char *namespace, *key;
+  GVariant *value;
+
+  if( strcmp( signal_name, "SettingChanged" ) ) return;
+
+  g_variant_get( parameters, "(&s&sv)", &namespace, &key, &value );
+
+  if( !strcmp( namespace, "org.freedesktop.appearance" ) &&
+      !strcmp( key, "color-scheme" ) &&
+      g_variant_is_of_type( value, G_VARIANT_TYPE_UINT32 ) )
+    gtkui_set_dark_theme( g_variant_get_uint32( value ) ==
+                          COLOR_SCHEME_PREFER_DARK );
+
+  g_variant_unref( value );
+}
+
+static void
+gtkui_gsettings_changed( GSettings *settings, gchar *key GCC_UNUSED,
+                         gpointer data GCC_UNUSED )
+{
+  char *color_scheme = g_settings_get_string( settings, "color-scheme" );
+
+  gtkui_set_dark_theme( !strcmp( color_scheme, "prefer-dark" ) );
+
+  g_free( color_scheme );
+}
+
+static int
+gtkui_follow_gsettings_color_scheme( void )
+{
+  GSettingsSchemaSource *source;
+  GSettingsSchema *schema;
+
+  source = g_settings_schema_source_get_default();
+  if( !source ) return 1;
+
+  schema = g_settings_schema_source_lookup( source,
+                                            "org.gnome.desktop.interface",
+                                            TRUE );
+  if( !schema ) return 1;
+
+  if( !g_settings_schema_has_key( schema, "color-scheme" ) ) {
+    g_settings_schema_unref( schema );
+    return 1;
+  }
+
+  interface_settings = g_settings_new_full( schema, NULL, NULL );
+  g_settings_schema_unref( schema );
+
+  g_signal_connect( interface_settings, "changed::color-scheme",
+                    G_CALLBACK( gtkui_gsettings_changed ), NULL );
+  gtkui_gsettings_changed( interface_settings, NULL, NULL );
+
+  return 0;
+}
+
+static void
+gtkui_follow_desktop_color_scheme( void )
+{
+  GError *error = NULL;
+  guint32 color_scheme;
+
+  settings_portal =
+    g_dbus_proxy_new_for_bus_sync( G_BUS_TYPE_SESSION,
+                                   G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES |
+                                   G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START,
+                                   NULL,
+                                   "org.freedesktop.portal.Desktop",
+                                   "/org/freedesktop/portal/desktop",
+                                   "org.freedesktop.portal.Settings",
+                                   NULL, &error );
+
+  if( settings_portal ) {
+    if( !gtkui_portal_read_color_scheme( &color_scheme ) ) {
+      g_signal_connect( settings_portal, "g-signal",
+                        G_CALLBACK( gtkui_portal_signal ), NULL );
+      gtkui_set_dark_theme( color_scheme == COLOR_SCHEME_PREFER_DARK );
+      return;
+    }
+    g_clear_object( &settings_portal );
+  } else {
+    g_error_free( error );
+  }
+
+  gtkui_follow_gsettings_color_scheme();
+}
+
 int
 ui_init( int *argc, char ***argv )
 {
@@ -166,6 +331,8 @@ ui_init( int *argc, char ***argv )
   GtkSettings *settings;
 
   gtk_init(argc,argv);
+
+  gtkui_follow_desktop_color_scheme();
 
   g_resources_register( gtkui_get_resource() );
 
@@ -327,6 +494,9 @@ ui_end(void)
   g_object_unref( ui_manager_menu );
 
   g_resources_unregister( gtkui_get_resource() );
+
+  g_clear_object( &settings_portal );
+  g_clear_object( &interface_settings );
 
   return 0;
 }

--- a/ui/gtk3/gtkui.c
+++ b/ui/gtk3/gtkui.c
@@ -64,6 +64,7 @@ GtkWidget *gtkui_window;
 GtkWidget *gtkui_drawing_area;
 
 static GtkWidget *menu_bar;
+static GtkWidget *header_bar;
 
 /* Wait until the window has reached its final size before applying
    fullscreen changes. See gtkui_window_configure() for more details */
@@ -95,6 +96,9 @@ static gboolean gtkui_make_menu(GtkAccelGroup **accel_group,
 				GtkWidget **menu_bar,
 				GtkActionEntry *menu_data,
 				guint menu_data_size);
+
+static void gtkui_make_header_bar( GtkWidget *menus,
+                                   GtkAccelGroup *accel_group );
 
 static gboolean gtkui_lose_focus( GtkWidget*, GdkEvent*, gpointer );
 static gboolean gtkui_gain_focus( GtkWidget*, GdkEvent*, gpointer );
@@ -385,7 +389,7 @@ ui_init( int *argc, char ***argv )
   }
 
   gtk_window_add_accel_group( GTK_WINDOW(gtkui_window), accel_group );
-  gtk_box_pack_start( GTK_BOX(box), menu_bar, FALSE, FALSE, 0 );
+  gtkui_make_header_bar( menu_bar, accel_group );
 
   gtkui_drawing_area = gtk_drawing_area_new();
   if(!gtkui_drawing_area) {
@@ -426,6 +430,69 @@ gtkui_menu_deactivate( GtkMenuShell *menu GCC_UNUSED,
 		       gpointer data GCC_UNUSED )
 {
   ui_mouse_resume();
+}
+
+static void
+gtkui_open_clicked( GtkButton *button GCC_UNUSED, gpointer data GCC_UNUSED )
+{
+  menu_file_open( NULL, NULL );
+}
+
+/* Move the top level menus out of the menu bar and into a single popup
+   menu hanging off a button in a header bar. The menu bar widget itself
+   is kept (the UI manager owns it, and the menu item paths used by
+   ui_menu_activate() still resolve) but never shown. */
+static void
+gtkui_make_header_bar( GtkWidget *menus, GtkAccelGroup *accel_group )
+{
+  GtkWidget *menu, *menu_button, *open_button;
+  GList *items, *item;
+
+  header_bar = gtk_header_bar_new();
+  gtk_header_bar_set_show_close_button( GTK_HEADER_BAR( header_bar ), TRUE );
+  gtk_header_bar_set_title( GTK_HEADER_BAR( header_bar ), "Fuse" );
+
+  menu = gtk_menu_new();
+  gtk_menu_set_accel_group( GTK_MENU( menu ), accel_group );
+  g_signal_connect( G_OBJECT( menu ), "deactivate",
+                    G_CALLBACK( gtkui_menu_deactivate ), NULL );
+
+  items = gtk_container_get_children( GTK_CONTAINER( menus ) );
+  for( item = items; item; item = item->next ) {
+    GtkWidget *menu_item = GTK_WIDGET( item->data );
+
+    g_object_ref( menu_item );
+    gtk_container_remove( GTK_CONTAINER( menus ), menu_item );
+    gtk_menu_shell_append( GTK_MENU_SHELL( menu ), menu_item );
+    g_object_unref( menu_item );
+  }
+  g_list_free( items );
+
+  open_button =
+    gtk_button_new_from_icon_name( "document-open-symbolic",
+                                   GTK_ICON_SIZE_BUTTON );
+  gtk_widget_set_tooltip_text( open_button, "Open a file (F3)" );
+  /* Every key belongs to the emulated machine, so nothing in the header
+     bar may take the keyboard focus: a focused button would swallow
+     Space and Enter */
+  gtk_widget_set_can_focus( open_button, FALSE );
+  g_signal_connect( G_OBJECT( open_button ), "clicked",
+                    G_CALLBACK( gtkui_open_clicked ), NULL );
+  gtk_header_bar_pack_start( GTK_HEADER_BAR( header_bar ), open_button );
+
+  menu_button = gtk_menu_button_new();
+  gtk_button_set_image( GTK_BUTTON( menu_button ),
+                        gtk_image_new_from_icon_name( "open-menu-symbolic",
+                                                      GTK_ICON_SIZE_BUTTON ) );
+  gtk_menu_button_set_popup( GTK_MENU_BUTTON( menu_button ), menu );
+  gtk_widget_set_tooltip_text( menu_button, "Main menu (F1)" );
+  gtk_widget_set_can_focus( menu_button, FALSE );
+  gtk_widget_add_accelerator( menu_button, "activate", accel_group,
+                              GDK_KEY_F1, 0, 0 );
+  gtk_header_bar_pack_end( GTK_HEADER_BAR( header_bar ), menu_button );
+
+  gtk_window_set_titlebar( GTK_WINDOW( gtkui_window ), header_bar );
+  gtk_widget_show_all( header_bar );
 }
 
 static gboolean
@@ -1226,20 +1293,10 @@ gtkui_scroll_connect( GtkTreeView *list, GtkAdjustment *adj )
                     G_CALLBACK( wheel_scroll_event ), adj );
 }
 
-int
-gtkui_menubar_get_height( void )
-{
-  GtkAllocation alloc;
-
-  gtk_widget_get_allocation( menu_bar, &alloc );
-
-  return alloc.height;
-}
-
 void
 gtkui_set_bars_visible( int visible )
 {
-  gtk_widget_set_visible( menu_bar, visible );
+  gtk_widget_set_visible( header_bar, visible );
   /* The status bar is only shown if the user has it enabled */
   gtkstatusbar_set_visibility( visible ? settings_current.statusbar : 0 );
 }

--- a/ui/gtk3/gtkui.c
+++ b/ui/gtk3/gtkui.c
@@ -63,15 +63,20 @@ GtkWidget *gtkui_window;
 /* The area into which the screen will be drawn */
 GtkWidget *gtkui_drawing_area;
 
-static GtkWidget *menu_bar;
 static GtkWidget *header_bar;
+
+/* The button in the header bar which shows the menu */
+static GtkWidget *menu_button;
 
 /* Wait until the window has reached its final size before applying
    fullscreen changes. See gtkui_window_configure() for more details */
 static int fullscreen_ready = 0;
 
-/* The UIManager used to create the menu bar */
-GtkUIManager *ui_manager_menu = NULL;
+/* The application, which owns the menu accelerators */
+static GtkApplication *gtkui_app = NULL;
+
+/* The builder holding the menu model created from menu_data.ui */
+static GtkBuilder *menu_builder = NULL;
 
 /* True if we were paused via the Machine/Pause menu item */
 static int paused = 0;
@@ -92,13 +97,9 @@ typedef struct gtkui_select_info {
 
 } gtkui_select_info;
 
-static gboolean gtkui_make_menu(GtkAccelGroup **accel_group,
-				GtkWidget **menu_bar,
-				GtkActionEntry *menu_data,
-				guint menu_data_size);
+static GtkWidget *gtkui_make_menu( void );
 
-static void gtkui_make_header_bar( GtkWidget *menus,
-                                   GtkAccelGroup *accel_group );
+static void gtkui_make_header_bar( GtkWidget *menu );
 
 static gboolean gtkui_lose_focus( GtkWidget*, GdkEvent*, gpointer );
 static gboolean gtkui_gain_focus( GtkWidget*, GdkEvent*, gpointer );
@@ -330,8 +331,7 @@ gtkui_follow_desktop_color_scheme( void )
 int
 ui_init( int *argc, char ***argv )
 {
-  GtkWidget *box;
-  GtkAccelGroup *accel_group;
+  GtkWidget *box, *menu;
   GtkSettings *settings;
 
   gtk_init(argc,argv);
@@ -340,7 +340,19 @@ ui_init( int *argc, char ***argv )
 
   g_resources_register( gtkui_get_resource() );
 
-  gtkui_window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+  /* The application is what holds the menu accelerators; Fuse runs its own
+     main loop, so it is registered but never run */
+  gtkui_app = gtk_application_new( "net.sourceforge.fuse_emulator.Fuse",
+                                   G_APPLICATION_NON_UNIQUE );
+  if( !g_application_register( G_APPLICATION( gtkui_app ), NULL, NULL ) ) {
+    fprintf(stderr,"%s: couldn't register the application at %s:%d\n",
+	    fuse_progname,__FILE__,__LINE__);
+    return 1;
+  }
+
+  gtkui_window = gtk_application_window_new( gtkui_app );
+  gtk_application_window_set_show_menubar( GTK_APPLICATION_WINDOW( gtkui_window ),
+                                           FALSE );
 
 #ifdef FUSE_ICON_AVAILABLE
   gtk_window_set_icon_name( GTK_WINDOW( gtkui_window ),
@@ -381,15 +393,14 @@ ui_init( int *argc, char ***argv )
   box = gtk_box_new( GTK_ORIENTATION_VERTICAL, 0 );
   gtk_container_add(GTK_CONTAINER(gtkui_window), box);
 
-  if( gtkui_make_menu( &accel_group, &menu_bar, gtkui_menu_data,
-                       gtkui_menu_data_size ) ) {
+  menu = gtkui_make_menu();
+  if( !menu ) {
     fprintf(stderr,"%s: couldn't make menus %s:%d\n",
 	    fuse_progname,__FILE__,__LINE__);
     return 1;
   }
 
-  gtk_window_add_accel_group( GTK_WINDOW(gtkui_window), accel_group );
-  gtkui_make_header_bar( menu_bar, accel_group );
+  gtkui_make_header_bar( menu );
 
   gtkui_drawing_area = gtk_drawing_area_new();
   if(!gtkui_drawing_area) {
@@ -435,38 +446,19 @@ gtkui_menu_deactivate( GtkMenuShell *menu GCC_UNUSED,
 static void
 gtkui_open_clicked( GtkButton *button GCC_UNUSED, gpointer data GCC_UNUSED )
 {
-  menu_file_open( NULL, NULL );
+  menu_file_open( NULL, NULL, NULL );
 }
 
-/* Move the top level menus out of the menu bar and into a single popup
-   menu hanging off a button in a header bar. The menu bar widget itself
-   is kept (the UI manager owns it, and the menu item paths used by
-   ui_menu_activate() still resolve) but never shown. */
+/* Hang the menu off a button in a header bar, and make that header bar the
+   window's titlebar */
 static void
-gtkui_make_header_bar( GtkWidget *menus, GtkAccelGroup *accel_group )
+gtkui_make_header_bar( GtkWidget *menu )
 {
-  GtkWidget *menu, *menu_button, *open_button;
-  GList *items, *item;
+  GtkWidget *open_button;
 
   header_bar = gtk_header_bar_new();
   gtk_header_bar_set_show_close_button( GTK_HEADER_BAR( header_bar ), TRUE );
   gtk_header_bar_set_title( GTK_HEADER_BAR( header_bar ), "Fuse" );
-
-  menu = gtk_menu_new();
-  gtk_menu_set_accel_group( GTK_MENU( menu ), accel_group );
-  g_signal_connect( G_OBJECT( menu ), "deactivate",
-                    G_CALLBACK( gtkui_menu_deactivate ), NULL );
-
-  items = gtk_container_get_children( GTK_CONTAINER( menus ) );
-  for( item = items; item; item = item->next ) {
-    GtkWidget *menu_item = GTK_WIDGET( item->data );
-
-    g_object_ref( menu_item );
-    gtk_container_remove( GTK_CONTAINER( menus ), menu_item );
-    gtk_menu_shell_append( GTK_MENU_SHELL( menu ), menu_item );
-    g_object_unref( menu_item );
-  }
-  g_list_free( items );
 
   open_button =
     gtk_button_new_from_icon_name( "document-open-symbolic",
@@ -487,46 +479,91 @@ gtkui_make_header_bar( GtkWidget *menus, GtkAccelGroup *accel_group )
   gtk_menu_button_set_popup( GTK_MENU_BUTTON( menu_button ), menu );
   gtk_widget_set_tooltip_text( menu_button, "Main menu (F1)" );
   gtk_widget_set_can_focus( menu_button, FALSE );
-  gtk_widget_add_accelerator( menu_button, "activate", accel_group,
-                              GDK_KEY_F1, 0, 0 );
   gtk_header_bar_pack_end( GTK_HEADER_BAR( header_bar ), menu_button );
 
   gtk_window_set_titlebar( GTK_WINDOW( gtkui_window ), header_bar );
   gtk_widget_show_all( header_bar );
 }
 
-static gboolean
-gtkui_make_menu(GtkAccelGroup **accel_group,
-                GtkWidget **menu_bar,
-                GtkActionEntry *menu_data,
-                guint menu_data_size)
+/* The state each menu item and submenu has been set to, before the
+   submenus above it are taken into account */
+static GHashTable *menu_item_states = NULL;
+
+/* The name of the GAction for the menu item with this UI independent
+   path: lower case, path separators turned into dashes and everything
+   which isn't a letter or a digit dropped, as in menu_data.pl */
+static char *
+gtkui_action_name( const char *path )
 {
-  *accel_group = NULL;
-  *menu_bar = NULL;
+  GString *name;
+  const char *p;
+
+  name = g_string_new( NULL );
+
+  for( p = path; *p; p++ ) {
+    char c = g_ascii_tolower( *p );
+
+    if( c == '/' ) c = '-';
+
+    if( g_ascii_isalnum( c ) || c == '-' ) g_string_append_c( name, c );
+  }
+
+  if( name->len && name->str[0] == '-' ) g_string_erase( name, 0, 1 );
+
+  return g_string_free( name, FALSE );
+}
+
+/* Show the menu when its accelerator is pressed */
+static void
+gtkui_primary_menu( GSimpleAction *action GCC_UNUSED,
+                    GVariant *parameter GCC_UNUSED, gpointer data GCC_UNUSED )
+{
+  gtk_toggle_button_set_active( GTK_TOGGLE_BUTTON( menu_button ), TRUE );
+}
+
+static GActionEntry gtkui_window_actions[] = {
+  { "primary-menu", gtkui_primary_menu, NULL, NULL, NULL }
+};
+
+static GtkWidget *
+gtkui_make_menu( void )
+{
+  GtkWidget *menu;
+  GMenuModel *model;
+  gtkui_menu_accel *entry;
   GError *error = NULL;
 
-  ui_manager_menu = gtk_ui_manager_new();
+  /* The menu items act on the window: the application turns the
+     accelerators into activations of the same actions */
+  g_action_map_add_action_entries( G_ACTION_MAP( gtkui_window ),
+                                   gtkui_menu_data, gtkui_menu_data_size,
+                                   NULL );
+  g_action_map_add_action_entries( G_ACTION_MAP( gtkui_window ),
+                                   gtkui_window_actions,
+                                   ARRAY_SIZE( gtkui_window_actions ), NULL );
 
-  /* Load actions */
-  GtkActionGroup *menu_action_group = gtk_action_group_new( "MenuActionGroup" );
-  gtk_action_group_add_actions( menu_action_group, menu_data, menu_data_size,
-                                NULL );
-  gtk_ui_manager_insert_action_group( ui_manager_menu, menu_action_group, 0 );
-  g_object_unref( menu_action_group );
-
-  /* Load the UI */
-  guint ui_menu_id =
-      gtk_ui_manager_add_ui_from_resource( ui_manager_menu, GTK_MENU_DATA, &error );
-  if( error ) {
-    g_error_free( error );
-    return TRUE;
+  for( entry = gtkui_menu_accels; entry->action; entry++ ) {
+    const char *accels[] = { entry->accel, NULL };
+    gtk_application_set_accels_for_action( gtkui_app, entry->action, accels );
   }
-  else if( !ui_menu_id ) return TRUE;
 
-  *accel_group = gtk_ui_manager_get_accel_group( ui_manager_menu );
+  {
+    const char *accels[] = { "F1", NULL };
+    gtk_application_set_accels_for_action( gtkui_app, "win.primary-menu",
+                                           accels );
+  }
 
-  *menu_bar = gtk_ui_manager_get_widget( ui_manager_menu, "/MainMenu" );
-  g_signal_connect( G_OBJECT( *menu_bar ), "deactivate",
+  menu_builder = gtk_builder_new();
+  if( !gtk_builder_add_from_resource( menu_builder, GTK_MENU_DATA, &error ) ) {
+    g_error_free( error );
+    return NULL;
+  }
+
+  model = G_MENU_MODEL( gtk_builder_get_object( menu_builder, "MainMenu" ) );
+  if( !model ) return NULL;
+
+  menu = gtk_menu_new_from_model( model );
+  g_signal_connect( G_OBJECT( menu ), "deactivate",
 		    G_CALLBACK( gtkui_menu_deactivate ), NULL );
 
   /* Start various menus in the 'off' state */
@@ -539,7 +576,7 @@ gtkui_make_menu(GtkAccelGroup **accel_group,
 #ifdef HAVE_LIB_XML2
   ui_menu_activate( UI_MENU_ITEM_FILE_SVG_CAPTURE, 0 );
 #endif
-  return FALSE;
+  return menu;
 }
 
 int
@@ -558,7 +595,13 @@ ui_end(void)
   /* Don't display the window whilst doing all this! */
   gtk_widget_hide( gtkui_window );
 
-  g_object_unref( ui_manager_menu );
+  g_clear_object( &menu_builder );
+  g_clear_object( &gtkui_app );
+
+  if( menu_item_states ) {
+    g_hash_table_destroy( menu_item_states );
+    menu_item_states = NULL;
+  }
 
   g_resources_unregister( gtkui_get_resource() );
 
@@ -694,13 +737,12 @@ static gboolean
 gtkui_delete( GtkWidget *widget GCC_UNUSED, GdkEvent *event GCC_UNUSED,
               gpointer data GCC_UNUSED )
 {
-  menu_file_exit( NULL, NULL );
+  menu_file_exit( NULL, NULL, NULL );
   return TRUE;
 }
 
 /* Called by the menu when File/Exit selected */
-void
-menu_file_exit( GtkAction *gtk_action GCC_UNUSED, gpointer data GCC_UNUSED )
+MENU_CALLBACK( menu_file_exit )
 {
   if( gtkui_confirm( "Exit Fuse?" ) ) {
 
@@ -710,7 +752,7 @@ menu_file_exit( GtkAction *gtk_action GCC_UNUSED, gpointer data GCC_UNUSED )
 
     /* Stop the paused state to allow us to exit (occurs from main
        emulation loop) */
-    if( paused ) menu_machine_pause( NULL, NULL );
+    if( paused ) menu_machine_pause( NULL, NULL, NULL );
 
     /* Ensure we break out of the main Z80 loop, there could be active
        breakpoints before the next event */
@@ -819,8 +861,7 @@ gtkui_run_main_loop( gpointer user_data GCC_UNUSED )
 }
 
 /* Machine/Pause */
-void
-menu_machine_pause( GtkAction *gtk_action GCC_UNUSED, gpointer data GCC_UNUSED )
+MENU_CALLBACK( menu_machine_pause )
 {
   int error;
 
@@ -848,8 +889,7 @@ menu_machine_pause( GtkAction *gtk_action GCC_UNUSED, gpointer data GCC_UNUSED )
 }
 
 /* Called by the menu when Machine/Reset selected */
-void
-menu_machine_reset( GtkAction *gtk_action GCC_UNUSED, guint action )
+MENU_CALLBACK_WITH_ACTION( menu_machine_reset )
 {
   int hard_reset = action;
   const char *message = "Reset?";
@@ -873,9 +913,7 @@ menu_machine_reset( GtkAction *gtk_action GCC_UNUSED, guint action )
 }
 
 /* Called by the menu when Machine/Select selected */
-void
-menu_machine_select( GtkAction *gtk_action GCC_UNUSED,
-                     gpointer data GCC_UNUSED )
+MENU_CALLBACK( menu_machine_select )
 {
   GtkWidget *content_area;
   gtkui_select_info dialog;
@@ -953,9 +991,7 @@ menu_machine_select_done( GtkWidget *widget GCC_UNUSED, gpointer user_data )
   gtk_main_quit();
 }
 
-void
-menu_machine_debugger( GtkAction *gtk_action GCC_UNUSED,
-                       gpointer data GCC_UNUSED )
+MENU_CALLBACK( menu_machine_debugger )
 {
   debugger_mode = DEBUGGER_MODE_HALTED;
   if( paused ) ui_debugger_activate();
@@ -969,14 +1005,12 @@ ui_widgets_reset( void )
   return 0;
 }
 
-void
-menu_help_keyboard( GtkAction *gtk_action GCC_UNUSED, gpointer data GCC_UNUSED )
+MENU_CALLBACK( menu_help_keyboard )
 {
   gtkui_picture( "keyboard.png", 0 );
 }
 
-void
-menu_help_about( GtkAction *gtk_action GCC_UNUSED, gpointer data GCC_UNUSED )
+MENU_CALLBACK( menu_help_about )
 {
   gtk_show_about_dialog( GTK_WINDOW( gtkui_window ),
                          "program-name", "Fuse",
@@ -1002,23 +1036,94 @@ gtkui_destroy_widget_and_quit( GtkWidget *widget, gpointer data GCC_UNUSED )
 
 /* Functions to activate and deactivate certain menu items */
 
+/* The state a menu item has been given, defaulting to active */
+static int
+menu_item_state( const char *name )
+{
+  gpointer state;
+
+  if( !menu_item_states ) return 1;
+
+  state = g_hash_table_lookup( menu_item_states, name );
+
+  return state ? GPOINTER_TO_INT( state ) - 1 : 1;
+}
+
+/* A menu item can be used only if it is active itself and so is every
+   submenu holding it. Submenus have no action of their own to disable
+   in a menu model, so their state is applied to their contents. */
+static int
+menu_item_effective_state( const char *name )
+{
+  const char *dash;
+  int state;
+
+  state = menu_item_state( name );
+
+  for( dash = strchr( name, '-' ); dash && state;
+       dash = strchr( dash + 1, '-' ) ) {
+    char *submenu = g_strndup( name, dash - name );
+    state = menu_item_state( submenu );
+    g_free( submenu );
+  }
+
+  return state;
+}
+
+/* Apply the state of this item, or of everything in this submenu, to the
+   actions the menu is built from. Returns the number of items updated. */
+static int
+menu_update_actions( const char *name )
+{
+  gchar **actions, **action;
+  size_t length = strlen( name );
+  int updated = 0;
+
+  actions = g_action_group_list_actions( G_ACTION_GROUP( gtkui_window ) );
+
+  for( action = actions; *action; action++ ) {
+    GAction *item;
+
+    if( strncmp( *action, name, length ) ) continue;
+    if( (*action)[length] && (*action)[length] != '-' ) continue;
+
+    item = g_action_map_lookup_action( G_ACTION_MAP( gtkui_window ), *action );
+    g_simple_action_set_enabled( G_SIMPLE_ACTION( item ),
+                                 menu_item_effective_state( *action ) );
+    updated++;
+  }
+
+  g_strfreev( actions );
+
+  return updated;
+}
+
 int
 ui_menu_item_set_active( const char *path, int active )
 {
-  GtkWidget *menu_item;
+  char *name;
+  int updated;
 
-  /* Translate UI-indepentment path to GTK UI path */
-  gchar *full_path = g_strdup_printf ("/MainMenu%s", path );
+  /* Translate the UI independent path to the name of the item's action,
+     the same way menu_data.pl does when it generates them */
+  name = gtkui_action_name( path );
 
-  menu_item = gtk_ui_manager_get_widget( ui_manager_menu, full_path );
-  g_free( full_path );
+  if( !menu_item_states )
+    menu_item_states = g_hash_table_new_full( g_str_hash, g_str_equal, g_free,
+                                              NULL );
 
-  if( !menu_item ) {
+  /* Zero means unset, so the states are stored one greater */
+  g_hash_table_insert( menu_item_states, g_strdup( name ),
+                       GINT_TO_POINTER( active ? 2 : 1 ) );
+
+  updated = menu_update_actions( name );
+  g_free( name );
+
+  if( !updated ) {
     ui_error( UI_ERROR_ERROR, "couldn't get menu item '%s' from menu_factory",
 	      path );
     return 1;
   }
-  gtk_widget_set_sensitive( menu_item, active );
 
   return 0;
 }

--- a/ui/gtk3/memory.c
+++ b/ui/gtk3/memory.c
@@ -317,9 +317,7 @@ goto_offset( GtkWidget *widget GCC_UNUSED, gpointer user_data GCC_UNUSED )
   gtk_adjustment_set_value( adjustment, offset );
 }
 
-void
-menu_machine_memorybrowser( GtkAction *gtk_action GCC_UNUSED,
-                            gpointer data GCC_UNUSED )
+MENU_CALLBACK( menu_machine_memorybrowser )
 {
   GtkWidget *dialog, *content_area, *scrollbar, *label, *offset;
   GtkWidget *box, *box_address, *box_hex, *box_data, *box_data_horizontal;

--- a/ui/gtk3/pokefinder.c
+++ b/ui/gtk3/pokefinder.c
@@ -76,9 +76,7 @@ enum
   NUM_COLS
 };
 
-void
-menu_machine_pokefinder( GtkAction *gtk_action GCC_UNUSED,
-                         gpointer data GCC_UNUSED )
+MENU_CALLBACK( menu_machine_pokefinder )
 {
   int error;
 

--- a/ui/gtk3/pokemem.c
+++ b/ui/gtk3/pokemem.c
@@ -75,9 +75,7 @@ static gboolean custom_value_edit( GtkTreeView *tree );
 void custom_value_changed( GtkCellRendererText *cell, gchar *path_string,
                            gchar *new_text, gpointer user_data );
 
-void
-menu_machine_pokememory( GtkAction *gtk_action GCC_UNUSED,
-                         gpointer data GCC_UNUSED )
+MENU_CALLBACK( menu_machine_pokememory )
 {
   fuse_emulation_pause();
 


### PR DESCRIPTION
The GTK 3 UI renders light whatever the desktop asks for, hangs its menus off a classic `GtkMenuBar`, and builds them with `GtkUIManager` and `GtkAction`, which GTK deprecated in 3.10. This makes the window follow the desktop's dark style preference, moves the menus into a `GtkHeaderBar` that serves as the window's titlebar, and rebuilds the whole menu layer on `GMenu` and `GAction`, leaving no deprecated GTK call in `ui/gtk3`.

**Before** (while the dark theme is active):
<img width="1384" height="1192" alt="01  Before" src="https://github.com/user-attachments/assets/e383844c-f610-447e-a63c-550eb5804dae" />

**After** (dark theme):
<img width="1384" height="1158" alt="02  After (Dark)" src="https://github.com/user-attachments/assets/8cce5185-70b1-43cb-90e9-457238da2d3d" />

**After** (light theme):
<img width="1384" height="1158" alt="02  After (Light)" src="https://github.com/user-attachments/assets/eb70325f-9b33-4c8c-b70a-00f4d4ebd5dc" />

### Follow the desktop's dark style

A GTK 3 application has to opt into the dark variant of its theme. `ui_init()` touches only one property on the settings object and it isn't that one:

https://github.com/speccytools/fusex/blob/4ab572c6a2d8c2f98df89a00416fc03169c937f4/ui/gtk3/gtkui.c#L179

so with GNOME's Dark Style enabled the menu bar and the window decorations are drawn from the light variant while the Spectrum display sits dark in the middle of them.

`gtkui_follow_desktop_color_scheme()` reads `color-scheme` from the `org.freedesktop.appearance` namespace of the XDG settings portal and keeps `gtk-application-prefer-dark-theme` in sync with it. Where the portal isn't running it falls back to GSettings on `org.gnome.desktop.interface`, checking that the schema exists first so it degrades quietly off GNOME. It subscribes to both sources, so toggling Dark Style re-themes a running Fuse.

### Move the menus into a header bar

The menu bar is gone. A `GtkHeaderBar` is the window's titlebar, carrying an Open button and a menu button that holds the five top level menus; F1 opens that menu, as it opened the menu bar before. Nothing in the header bar can take the keyboard focus: `gtkkeyboard_keypress()` returns the value of `input_event()`, which is 0 on success, so GTK treats every key as unhandled and forwards it to the focus widget — a focusable button would swallow Space and Enter, which belong to the emulated machine.

A header bar is a titlebar rather than a widget inside the window's content, and the code sizing the display assumed the latter in two places.

`gtk_window_resize()` and `gtk_window_set_geometry_hints()` are both in content coordinates: GTK adds the titlebar height to the size asked for. Counting the header bar in `extra_height`

https://github.com/speccytools/fusex/blob/4ab572c6a2d8c2f98df89a00416fc03169c937f4/ui/gtk3/gtkdisplay.c#L666

would therefore make the window one header bar taller than the display needs and letterbox it, so `extra_height` now accounts for the status bar alone.

The drawing area took its size from the window's `configure-event` minus that same chrome. With client side decorations the window's size also covers the invisible border drawn around it, which no chrome measurement accounts for. `drawing_area_resize_callback()` is now the drawing area's own `size-allocate` handler and uses its allocation directly, which needs no arithmetic and is right with or without decorations.

### Rebuild the menus on GMenu and GAction

`menu_data.pl` generates a `GMenu` model and a table of `GActionEntry` from `menu_data.dat` in place of the `GtkUIManager` XML and `GtkActionEntry` array; separators become sections, and each item's action name is derived from its path. `MENU_CALLBACK` in `menu.h` carries the `GAction` signature, which moves every callback with one macro change. The debugger window's View menu becomes a menu bar built from a model, its toggles stateful boolean actions.

The menu is realised with `gtk_menu_new_from_model()` rather than as a popover. GTK 3 draws no accelerator on a popover menu item, so a popover would silently drop the shortcut from every item that has one — F3 on Open, F5 on Reset, F7 and F8 on the tape. The main window is a `GtkApplicationWindow` so that the application can own those accelerators; Fuse runs its own main loop, so the application is registered and never run.

`ui_menu_item_set_active()` derives an action name from its UI independent path the same way the generator does, which is how a path such as `/Media/Tape/Record Stop` still finds its item. A menu model offers no way to disable a submenu — GTK 3 ignores the action of an item that has one — so the state of a submenu is applied to the items below it, combined with each item's own state so that re-enabling a submenu cannot enable an item that is disabled in its own right. An unavailable submenu therefore still opens, with everything inside it greyed.

### Report a debugger that won't open

`ui_debugger_activate()` pauses the emulation before it builds the debugger dialog, and only `deactivate_debugger()` unpauses it:

https://github.com/speccytools/fusex/blob/4ab572c6a2d8c2f98df89a00416fc03169c937f4/ui/gtk3/debugger.c#L243-L249

Its early returns therefore leave the emulation paused with no window to resume it from, so a debugger that fails to build presents as a frozen emulator rather than as an error. Those paths now unpause, and the failures building the menu report through `ui_error()` instead of returning a bare 1.

### Verification

Deprecation warnings are suppressed by `configure`, which passes `-DGDK_DISABLE_DEPRECATION_WARNINGS`. Building `ui/gtk3` with `-DGDK_VERSION_MIN_REQUIRED=GDK_VERSION_3_24` instead reports 18 call sites across 10 deprecated APIs on the base commit, and none after this branch.

Driven headlessly under Xvfb, every path passed to `ui_menu_item_set_active()` resolves and the run is free of GTK warnings and criticals. With keys synthesised through XTest, Space, Enter and Tab leave the file dialog closed, the cursor keys reach the emulated machine, and F1 opens the menu with its accelerators shown.

`fuse --debugger-command "break 0x38"` stops on the first interrupt: the debugger dialog opens with its panes populated and the disassembly at the breakpoint, and View/Registers hides the register pane.