### PR TITLE
Make the null UI build on macOS and Linux

### DIFF
--- a/.github/workflows/null-ui-libfusex.yml
+++ b/.github/workflows/null-ui-libfusex.yml
@@ -1,0 +1,81 @@
+name: Null UI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  null-ui-build:
+    name: Null UI (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-26
+    env:
+      LIBSPECTRUM_DIR: 3rdparty/libspectrum
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Fetch libspectrum source
+        run: git submodule update --init "$LIBSPECTRUM_DIR"
+
+      - name: Capture libspectrum SHA
+        id: libspectrum-sha
+        run: echo "sha=$(git -C "$LIBSPECTRUM_DIR" rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies (Ubuntu)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y autoconf automake libtool pkg-config bison flex \
+            build-essential libxml2-dev zlib1g-dev libpng-dev perl
+
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install automake libtool pkg-config libpng
+
+      - name: Restore libspectrum cache
+        id: libspectrum-cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ${{ env.LIBSPECTRUM_DIR }}/libspectrum-installed
+          key: libspectrum-${{ matrix.os }}-${{ steps.libspectrum-sha.outputs.sha }}-fakeglib
+
+      - name: Build libspectrum
+        if: steps.libspectrum-cache.outputs.cache-hit != 'true'
+        working-directory: ${{ env.LIBSPECTRUM_DIR }}
+        run: |
+          ./autogen.sh
+          ./configure --without-libgcrypt --without-bzip2 --with-fake-glib --prefix="$GITHUB_WORKSPACE/$LIBSPECTRUM_DIR/libspectrum-installed"
+          make
+          make install
+
+      - name: Save libspectrum cache
+        if: steps.libspectrum-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ env.LIBSPECTRUM_DIR }}/libspectrum-installed
+          key: libspectrum-${{ matrix.os }}-${{ steps.libspectrum-sha.outputs.sha }}-fakeglib
+
+      - name: Autogen
+        run: ./autogen.sh
+
+      - name: Configure
+        run: |
+          PKG_CONFIG_PATH="$GITHUB_WORKSPACE/$LIBSPECTRUM_DIR/libspectrum-installed/lib/pkgconfig" \
+            ./configure --with-null-ui --without-pthread --with-audio-driver=null
+
+      - name: Build
+        run: make
+
+      - name: Run the test suite
+        run: make check

--- a/Makefile.am
+++ b/Makefile.am
@@ -83,7 +83,10 @@ fuse_DEPENDENCIES =
 EXTRA_fuse_SOURCES =
 
 BUILT_SOURCES = options.h settings.c settings.h \
-		debugger/commandy.c debugger/commandy.h debugger/commandl.c
+		debugger/commandy.c \
+		debugger/commandy.h \
+		debugger/commandy.tab.h \
+		debugger/commandl.c
 
 if COMPAT_WIN32
 settings.c: settings-win32.pl settings.dat
@@ -95,6 +98,11 @@ endif
 
 settings.h: settings-header.pl settings.dat
 	$(AM_V_GEN)$(PERL) -I$(srcdir)/perl $(srcdir)/settings-header.pl $(srcdir)/settings.dat > $@.tmp && mv $@.tmp $@
+
+# commandl.l #includes "commandy.tab.h" (the bison default name the Xcode build
+# produces); automake's yacc rule emits commandy.h, so alias it.
+debugger/commandy.tab.h: debugger/commandy.h
+	$(AM_V_GEN)cp $< $@
 
 options.h: $(srcdir)/perl/cpp-perl.pl config.h $(srcdir)/ui/@OPTIONS_DIR@/options-header.pl $(srcdir)/ui/options.dat $(srcdir)/perl/Fuse.pm $(srcdir)/perl/Fuse/Dialog.pm
 	$(AM_V_GEN)$(PERL) $(srcdir)/perl/cpp-perl.pl config.h $(srcdir)/ui/options.dat | $(PERL) -I$(srcdir)/perl $(srcdir)/ui/@OPTIONS_DIR@/options-header.pl - public > $@.tmp && mv $@.tmp $@

--- a/settings.pl
+++ b/settings.pl
@@ -225,11 +225,13 @@ sub emit_forward_declarations {
     print << 'CODE';
 static int read_config_file( settings_info *settings );
 
+#ifndef UI_NULL
 #ifdef HAVE_LIB_XML2
 static int parse_xml( xmlDocPtr doc, settings_info *settings );
 #else				/* #ifdef HAVE_LIB_XML2 */
 static int parse_ini( utils_file *file, settings_info *settings );
 #endif				/* #ifdef HAVE_LIB_XML2 */
+#endif				/* #ifndef UI_NULL */
 CODE
     print "\n";
   }
@@ -491,6 +493,24 @@ CODE
 
 sub emit_config_io_portable {
   print hashline( __LINE__ ), << 'CODE';
+
+#ifdef UI_NULL
+
+/* The null UI has no user and therefore no preferences. */
+
+static int
+read_config_file( settings_info *settings GCC_UNUSED )
+{
+  return 0;
+}
+
+int
+settings_write_config( settings_info *settings GCC_UNUSED )
+{
+  return 0;
+}
+
+#else				/* #ifdef UI_NULL */
 
 #ifdef HAVE_LIB_XML2
 
@@ -938,6 +958,8 @@ error:
 }
 
 #endif				/* #ifdef HAVE_LIB_XML2 */
+
+#endif				/* #ifdef UI_NULL */
 CODE
 }
 

--- a/ui.c
+++ b/ui.c
@@ -697,7 +697,7 @@ static const struct menu_item_entries menu_item_lookup[] = {
 
 };
 
-#ifndef __APPLE__
+#if !defined __APPLE__ && !defined UI_NULL
 int
 ui_menu_activate( ui_menu_item item, int active )
 {
@@ -733,7 +733,7 @@ ui_menu_activate( ui_menu_item item, int active )
   ui_error( UI_ERROR_ERROR, "ui_menu_activate: unknown item %d", item );
   return 1;
 }
-#endif			/* #ifndef __APPLE__ */
+#endif			/* !__APPLE__ && !UI_NULL */
 
 void
 ui_menu_disk_update( void )
@@ -756,7 +756,7 @@ ui_menu_disk_update( void )
   ui_media_drive_update_parent_menus();
 }
 
-#ifndef __APPLE__
+#if !defined __APPLE__ && !defined UI_NULL
 int
 ui_tape_write( void )
 {
@@ -799,7 +799,7 @@ ui_mdr_write( int which, int saveas )
 
   return err;
 }
-#endif			/* #ifndef __APPLE__ */
+#endif			/* !__APPLE__ && !UI_NULL */
 
 #ifdef USE_WIDGET
 int

--- a/ui/null/null_ui.c
+++ b/ui/null/null_ui.c
@@ -29,7 +29,7 @@
 #include "../uijoystick.c"
 
 keysyms_map_t keysyms_map[] = {
-  { 0, 0 } /* End marker */
+  { 0xff, 0 } /* End marker */
 };
 
 scaler_type
@@ -256,4 +256,28 @@ void
 uidisplay_putpixel( int x, int y, int colour )
 {
   /* Do nothing */
+}
+
+int
+ui_menu_activate( ui_menu_item item, int active )
+{
+  return 0;
+}
+
+int
+ui_tape_write( void )
+{
+  return 0;
+}
+
+int
+ui_disk_write( int which, int saveas )
+{
+  return 0;
+}
+
+int
+ui_mdr_write( int which, int saveas )
+{
+  return 0;
 }


### PR DESCRIPTION
The null UI (`--with-null-ui`) does not build:

```sh
cd 3rdparty/libspectrum
./autogen.sh
./configure --without-libgcrypt --without-bzip2 --with-fake-glib \
  --prefix="$PWD/libspectrum-installed"
make && make install
cd ../..

./autogen.sh
PKG_CONFIG_PATH="$PWD/3rdparty/libspectrum/libspectrum-installed/lib/pkgconfig" \
  ./configure --with-null-ui --without-pthread --with-audio-driver=null
make
```

```
debugger/commandl.l:36:10: fatal error: 'commandy.tab.h' file not found
   36 | #include "commandy.tab.h"
      |          ^~~~~~~~~~~~~~~~
1 error generated.
make[1]: *** [Makefile:3097: debugger/commandl.o] Error 1
```

The second commit makes the Null UI ignore the user's config:
1. It is needed for `./fuse --unittests` to pass regardless of the current user's settings.
2. The Null UI (the headless mode) should not use the user's settings since there's no user involved.