### PR TITLE
Build libfusex, the emulator core as a shared library

### DIFF
--- a/.github/scripts/libfusex_boot_test.py
+++ b/.github/scripts/libfusex_boot_test.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+import ctypes
+import os
+import sys
+
+COPYRIGHT = 0x1539
+EXPECTED = b"\x7f 1982 Sinclair Research Ltd"
+
+if len(sys.argv) != 3:
+    sys.exit(f"usage: {sys.argv[0]} <library> <rom directory>")
+
+library, rom_dir = (os.path.abspath(path) for path in sys.argv[1:])
+
+lib = ctypes.CDLL(library)
+lib.readbyte.argtypes = [ctypes.c_uint16]
+lib.readbyte.restype = ctypes.c_uint8
+
+argv = (ctypes.c_char_p * 6)(
+    b"fusex", b"--machine", b"48", b"--rom-dir", rom_dir.encode(), b"--no-banner"
+)
+if lib.fuse_init(6, argv) != 0:
+    sys.exit("fuse_init failed")
+
+message = bytearray()
+address = COPYRIGHT
+while True:
+    code = lib.readbyte(address)
+    message.append(code & 0x7F)
+    if code & 0x80:
+        break
+    address += 1
+
+lib.fuse_end()
+
+if bytes(message) != EXPECTED:
+    sys.exit(f"expected {EXPECTED!r} at {COPYRIGHT:#06x}, read {bytes(message)!r}")
+
+print(f"ok: {bytes(message)!r}")

--- a/.github/workflows/libfusex.yml
+++ b/.github/workflows/libfusex.yml
@@ -1,4 +1,4 @@
-name: Null UI
+name: libfusex
 
 on:
   pull_request:
@@ -6,8 +6,8 @@ on:
     branches: [main]
 
 jobs:
-  null-ui-build:
-    name: Null UI (${{ matrix.os }})
+  libfusex:
+    name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/null-ui-libfusex.yml
+++ b/.github/workflows/null-ui-libfusex.yml
@@ -12,9 +12,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-26
+        include:
+          - os: ubuntu-latest
+            libfusex: libfusex.so
+          - os: macos-26
+            libfusex: libfusex.dylib
     env:
       LIBSPECTRUM_DIR: 3rdparty/libspectrum
 
@@ -48,14 +50,16 @@ jobs:
         uses: actions/cache/restore@v6
         with:
           path: ${{ env.LIBSPECTRUM_DIR }}/libspectrum-installed
-          key: libspectrum-${{ matrix.os }}-${{ steps.libspectrum-sha.outputs.sha }}-fakeglib
+          key: libspectrum-${{ matrix.os }}-${{ steps.libspectrum-sha.outputs.sha }}-fakeglib-static-pic
 
       - name: Build libspectrum
         if: steps.libspectrum-cache.outputs.cache-hit != 'true'
         working-directory: ${{ env.LIBSPECTRUM_DIR }}
         run: |
           ./autogen.sh
-          ./configure --without-libgcrypt --without-bzip2 --with-fake-glib --prefix="$GITHUB_WORKSPACE/$LIBSPECTRUM_DIR/libspectrum-installed"
+          ./configure --without-libgcrypt --without-bzip2 --with-fake-glib \
+            --disable-shared --with-pic \
+            --prefix="$GITHUB_WORKSPACE/$LIBSPECTRUM_DIR/libspectrum-installed"
           make
           make install
 
@@ -64,7 +68,7 @@ jobs:
         uses: actions/cache/save@v6
         with:
           path: ${{ env.LIBSPECTRUM_DIR }}/libspectrum-installed
-          key: libspectrum-${{ matrix.os }}-${{ steps.libspectrum-sha.outputs.sha }}-fakeglib
+          key: libspectrum-${{ matrix.os }}-${{ steps.libspectrum-sha.outputs.sha }}-fakeglib-static-pic
 
       - name: Autogen
         run: ./autogen.sh
@@ -79,3 +83,6 @@ jobs:
 
       - name: Run the test suite
         run: make check
+
+      - name: Test libfusex
+        run: python3 .github/scripts/libfusex_boot_test.py ${{ matrix.libfusex }} roms

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@
 /lib/tests/idedos-success.hdf
 /lib/tests/success.d80
 /lib/tests/success.mgt
+/libfusex.dylib
+/libfusex.so
 /libtool
 /ltmain.sh
 /m4/libtool.m4

--- a/Makefile.am
+++ b/Makefile.am
@@ -28,6 +28,7 @@ noinst_PROGRAMS =
 
 fuse_SOURCES = display.c \
 	event.c \
+	main.c \
 	fuse.c \
 	input.c \
 	keyboard.c \

--- a/Makefile.darwin
+++ b/Makefile.darwin
@@ -1,4 +1,4 @@
-.PHONY: 3rdparty audiofile libgcrypt FuseGenerator FuseImporter mbedtls libssh2 clean-3rdparty list-teams fusex archive dist dmg appcast appcast-push release release-clean release-notarize release-export clean
+.PHONY: 3rdparty audiofile libgcrypt FuseGenerator FuseImporter mbedtls libssh2 libspectrum libfusex clean-3rdparty list-teams fusex archive dist dmg appcast appcast-push release release-clean release-notarize release-export clean
 
 # Signing parameters (can be overridden from command line)
 # By default, use the signing settings already stored in the Xcode projects.
@@ -11,6 +11,14 @@ PROVISIONING_PROFILE_SPECIFIER ?=
 # Archive path (can be overridden from command line)
 # Example: make archive ARCHIVE_PATH=./build/FuseX.xcarchive
 ARCHIVE_PATH ?= ./build/FuseX.xcarchive
+
+# libfusex, the shared library shipped in the bundle, and the libspectrum it
+# absorbs. Built out of tree so the autotools build does not fight the app
+# build over the source root. LIBFUSEX_BUILD_DIR is the path
+# FuseX.xcodeproj copies into Frameworks.
+LIBSPECTRUM_DIR = 3rdparty/libspectrum
+LIBSPECTRUM_PREFIX = $(CURDIR)/$(LIBSPECTRUM_DIR)/libspectrum-installed
+LIBFUSEX_BUILD_DIR = build/libfusex
 
 # Release paths and notarization profile
 DIST_APP_PATH ?= dist/FuseX.app
@@ -128,6 +136,28 @@ libssh2: mbedtls
 		CONFIGURATION_BUILD_DIR=build/Deployment \
 		$(XCODEBUILD_SIGN_ARGS)
 
+# Static, so libfusex absorbs it rather than recording the path it was built at.
+libspectrum:
+	@echo "Building libspectrum..."
+	cd $(LIBSPECTRUM_DIR) && \
+	./autogen.sh && \
+	./configure --without-libgcrypt --without-bzip2 --with-fake-glib \
+		--disable-shared --with-pic --prefix="$(LIBSPECTRUM_PREFIX)" && \
+	$(MAKE) && \
+	$(MAKE) install
+
+# --without-png keeps the Homebrew libpng out; every remaining dependency is a
+# system library, so the bundle is loadable wherever it is installed.
+libfusex: libspectrum
+	@echo "Building libfusex..."
+	./autogen.sh
+	@mkdir -p $(LIBFUSEX_BUILD_DIR)
+	cd $(LIBFUSEX_BUILD_DIR) && \
+	PKG_CONFIG_PATH="$(LIBSPECTRUM_PREFIX)/lib/pkgconfig" \
+	$(CURDIR)/configure --with-null-ui --without-pthread \
+		--with-audio-driver=null --without-png && \
+	$(MAKE)
+
 list-teams:
 	@echo "Available code signing identities and development teams:"
 	@echo ""
@@ -147,7 +177,11 @@ list-teams:
 		echo "No code signing identities found. Make sure you have certificates installed in your keychain."; \
 	fi
 
+# libfusex is built from the recipe rather than named as a prerequisite: fusepb
+# regenerates sources the libfusex build compiles, and under make -j sibling
+# prerequisites run concurrently whatever order they are written in.
 fusex: 3rdparty fusepb
+	$(MAKE) -f Makefile.darwin libfusex
 	@echo "Building FuseX app..."
 	cd fusepb && \
 	xcodebuild -project FuseX.xcodeproj \
@@ -166,6 +200,7 @@ release-clean:
 	@rm -rf "$(DIST_APP_PATH)"
 
 archive: 3rdparty fusepb
+	$(MAKE) -f Makefile.darwin libfusex
 	@echo "Archiving FuseX app..."
 	@mkdir -p build
 	cd fusepb && \

--- a/configure.ac
+++ b/configure.ac
@@ -920,6 +920,73 @@ if test "x$missing_routines" = x; then
 fi
 AC_MSG_RESULT($missing_routines)
 
+FUSEX_LIB=
+FUSEX_LDFLAGS=
+LIBSPECTRUM_ARCHIVE=
+LIBSPECTRUM_PRIVATE_LIBS=
+
+AS_IF([test "$UI" = null], [
+
+AC_MSG_CHECKING(how to link the libfusex shared library)
+case "$host_os" in
+  darwin*)
+    FUSEX_LIB=libfusex.dylib
+    FUSEX_LDFLAGS='-dynamiclib -install_name @rpath/libfusex.dylib'
+    ;;
+  linux*|*bsd*)
+    dnl An ELF linker allows undefined symbols in a shared object, so without
+    dnl --no-undefined they surface at the host's dlopen. ld64 errors anyway.
+    FUSEX_LIB=libfusex.so
+    FUSEX_LDFLAGS='-shared -Wl,-soname,libfusex.so -Wl,--no-undefined'
+    CFLAGS="$CFLAGS -fPIC"
+    ;;
+  *)
+    AC_MSG_RESULT(unknown)
+    AC_MSG_ERROR([libfusex has not been built for $host_os])
+    ;;
+esac
+AC_MSG_RESULT($FUSEX_LIB)
+
+dnl A shared libspectrum records the path it was installed at, which a host
+dnl loading libfusex from elsewhere cannot resolve. -lspectrum leaves the
+dnl choice to the linker's search order, and the shared library wins wherever
+dnl both exist, so name the archive.
+AC_MSG_CHECKING(for the libspectrum archive)
+LIBSPECTRUM_ARCHIVE=`$PKG_CONFIG --variable=libdir libspectrum 2>/dev/null`/libspectrum.a
+if test -f "$LIBSPECTRUM_ARCHIVE"; then
+  AC_MSG_RESULT($LIBSPECTRUM_ARCHIVE)
+else
+  LIBSPECTRUM_ARCHIVE=-lspectrum
+  AC_MSG_RESULT([not found, linking libspectrum dynamically])
+  AC_MSG_WARN([libfusex will depend on a shared libspectrum at the path it was
+               built against; build libspectrum with --disable-shared
+               --with-pic for a relocatable library])
+fi
+
+dnl What the archive itself leaves unresolved, from the .pc file's Libs.private.
+AC_MSG_CHECKING(for libspectrum's private link flags)
+LIBSPECTRUM_PRIVATE_LIBS=`$PKG_CONFIG --static --libs libspectrum 2>/dev/null`
+LIBSPECTRUM_PRIVATE_LIBS=`echo " $LIBSPECTRUM_PRIVATE_LIBS " | sed 's/ -lspectrum / /g'`
+AC_MSG_RESULT($LIBSPECTRUM_PRIVATE_LIBS)
+
+dnl Libs.private omits libbz2, and fuse does not link bzip2 itself, so a
+dnl libspectrum built with bzip2 leaves BZ2_* unresolved. Ask the archive.
+AC_MSG_CHECKING(whether the libspectrum archive needs libbz2)
+if test -f "$LIBSPECTRUM_ARCHIVE" &&
+   $NM -u "$LIBSPECTRUM_ARCHIVE" 2>/dev/null | grep BZ2_ >/dev/null 2>&1; then
+  LIBSPECTRUM_PRIVATE_LIBS="$LIBSPECTRUM_PRIVATE_LIBS -lbz2"
+  AC_MSG_RESULT(yes)
+else
+  AC_MSG_RESULT(no)
+fi
+
+])
+
+AC_SUBST(FUSEX_LIB)
+AC_SUBST(FUSEX_LDFLAGS)
+AC_SUBST(LIBSPECTRUM_ARCHIVE)
+AC_SUBST(LIBSPECTRUM_PRIVATE_LIBS)
+
 dnl Work out which compatibility routines to use
 AC_MSG_CHECKING(which compatibility routines to use)
 case "$host_os" in

--- a/fuse.c
+++ b/fuse.c
@@ -571,6 +571,7 @@ static void fuse_show_help( void )
    "--no-banner            Suppress the startup copyright banner.\n"
    "--playback <filename>  Play back RZX file <filename>.\n"
    "--record <filename>    Record to RZX file <filename>.\n"
+   "--rom-dir <dir>        Look for ROM images in <dir> first.\n"
    "--separation <type>    Use ACB/ABC stereo for the AY-3-8912 sound chip.\n"
    "--snapshot <filename>  Load snapshot <filename>.\n"
    "--speed <percentage>   How fast should emulation run?\n"

--- a/fuse.c
+++ b/fuse.c
@@ -31,19 +31,7 @@
 #include <sys/types.h>
 #include <time.h>
 
-#ifdef WIN32
-#include <windows.h>
-#endif				/* #ifdef WIN32 */
-
 #include <unistd.h>
-
-/* We need to include SDL.h on Mac O X and Windows to do some magic
-   bootstrapping by redefining main. As we now allow SDL joystick code to be
-   used in the GTK and Xlib UIs we need to also do the magic when that code is
-   in use, feel free to look away for the next line */
-#if defined UI_SDL || defined UI_SDL2 || (defined USE_JOYSTICK && (defined UI_X || defined UI_GTK) )
-#include <SDL.h>		/* Needed on MacOS X and Windows */
-#endif /* #if defined UI_SDL || defined UI_SDL2 || (defined USE_JOYSTICK && (defined UI_X || defined UI_GTK) ) */
 
 #ifdef GEKKO
 /* #include <fat.h>
@@ -171,50 +159,6 @@ static int parse_nonoption_args( int argc, char **argv, int first_arg,
 				 start_files_t *start_files );
 static int do_start_files( start_files_t *start_files );
 static void free_start_files( start_files_t *start_files );
-
-#ifdef UI_WIN32
-/* The Win32 UI supplies WinMain(), which calls this */
-int fuse_main(int argc, char **argv)
-#elif defined UI_COCOA
-/* fusepb/main.m supplies main() and Emulator.m calls fuse_init() itself, so
-   this entry point goes unused; it is renamed only to avoid colliding with
-   the one in main.m */
-int old_main(int argc, char **argv)
-#else
-int main(int argc, char **argv)
-#endif
-{
-  int r = 0;
-
-#ifdef WIN32
-  SetErrorMode( SEM_FAILCRITICALERRORS | SEM_NOOPENFILEERRORBOX );
-#endif
-
-#ifdef GEKKO
-  fatInitDefault();
-#endif				/* #ifdef GEKKO */
-  
-  if(fuse_init(argc,argv)) {
-    fprintf(stderr,"%s: error initialising -- giving up!\n", fuse_progname);
-    return 1;
-  }
-
-  if( settings_current.show_help ||
-      settings_current.show_version ) return 0;
-
-  if( settings_current.unittests ) {
-    r = unittests_run();
-  } else {
-    while( !fuse_exiting ) {
-      spectrum_do_frame();
-    }
-    r = debugger_get_exit_code();
-  }
-
-  fuse_end();
-  
-  return r;
-}
 
 static int
 fuse_libspectrum_init( void *context )

--- a/fusepb/FuseX.xcodeproj/project.pbxproj
+++ b/fusepb/FuseX.xcodeproj/project.pbxproj
@@ -309,6 +309,7 @@
 		B6F66E351E473D68005B270A /* memory_pages.c in Sources */ = {isa = PBXBuildFile; fileRef = B6F66E331E473D68005B270A /* memory_pages.c */; };
 		B6FA759D0C1D7507007F5A10 /* audiofile.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B6FA759C0C1D7507007F5A10 /* audiofile.framework */; };
 		B6FA75C60C1D76A5007F5A10 /* audiofile.framework in Copy Files */ = {isa = PBXBuildFile; fileRef = B6FA759C0C1D7507007F5A10 /* audiofile.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		FE1B00120001000000000002 /* libfusex.dylib in Copy Files */ = {isa = PBXBuildFile; fileRef = FE1B00110001000000000001 /* libfusex.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		BAE50FF21E9FEF6A73AC6175 /* 256s-3.rom in Resources */ = {isa = PBXBuildFile; fileRef = B47A67E8F3CF893BB8B0B51B /* 256s-3.rom */; };
 		C0C0617E40B5762CC966FBB0 /* opu.icns in Resources */ = {isa = PBXBuildFile; fileRef = E1F94955E564E275BA43C35D /* opu.icns */; };
 		C56D1BEAC229ADB9FFF68BA0 /* mgt.icns in Resources */ = {isa = PBXBuildFile; fileRef = E58E141DFD2813AA4F512B32 /* mgt.icns */; };
@@ -454,6 +455,7 @@
 				FE8E40202FD71100009FDB81 /* (null) in Copy Files */,
 				B6D65C3818A645A100170B64 /* gcrypt.framework in Copy Files */,
 				FE8E3FD92FD70FFB009FDB81 /* libssh2.framework in Copy Files */,
+				FE1B00120001000000000002 /* libfusex.dylib in Copy Files */,
 			);
 			name = "Copy Files";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -749,6 +751,7 @@
 		B6D2989105B061CB00C2AA14 /* MemoryBrowserController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MemoryBrowserController.h; path = controllers/MemoryBrowserController.h; sourceTree = "<group>"; };
 		B6D2989205B061CB00C2AA14 /* MemoryBrowserController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MemoryBrowserController.m; path = controllers/MemoryBrowserController.m; sourceTree = "<group>"; };
 		B6D65C3618A6431500170B64 /* gcrypt.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = gcrypt.framework; path = ../3rdparty/libgcrypt/build/Deployment/gcrypt.framework; sourceTree = "<group>"; };
+		FE1B00110001000000000001 /* libfusex.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libfusex.dylib; path = ../build/libfusex/libfusex.dylib; sourceTree = "<group>"; };
 		B6D670451DD6CB6B0014914E /* FuseXHelp.help */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FuseXHelp.help; sourceTree = BUILT_PRODUCTS_DIR; };
 		B6D670471DD6CB6B0014914E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B6D71DCC1F6A94750000D666 /* divmmc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = divmmc.c; sourceTree = "<group>"; };

--- a/main.c
+++ b/main.c
@@ -1,0 +1,88 @@
+/* main.c: Fuse executable entry point
+   Copyright (c) 1999-2026 Philip Kendall and others
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License along
+   with this program; if not, write to the Free Software Foundation, Inc.,
+   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+   Author contact information:
+
+   E-mail: philip-fuse@shadowmagic.org.uk
+*/
+
+#include "config.h"
+
+#include <stdio.h>
+
+#ifdef WIN32
+#include <windows.h>
+#endif
+
+/* We need to include SDL.h on Mac OS X and Windows to do some magic
+   bootstrapping by redefining main. As we now allow SDL joystick code to be
+   used in the GTK and Xlib UIs we need to also do the magic when that code is
+   in use, feel free to look away for the next line */
+#if defined UI_SDL || defined UI_SDL2 || (defined USE_JOYSTICK && (defined UI_X || defined UI_GTK) )
+#include <SDL.h>		/* Needed on MacOS X and Windows */
+#endif /* #if defined UI_SDL || defined UI_SDL2 || (defined USE_JOYSTICK && (defined UI_X || defined UI_GTK) ) */
+
+#include "debugger/debugger.h"
+#include "fuse.h"
+#include "settings.h"
+#include "spectrum.h"
+#include "unittests/unittests.h"
+
+#ifdef UI_WIN32
+/* The Win32 UI supplies WinMain(), which calls this. */
+int
+fuse_main( int argc, char **argv )
+#elif defined UI_COCOA
+/* The Cocoa app supplies its own main() in main.m. */
+int
+old_main( int argc, char **argv )
+#else
+int
+main( int argc, char **argv )
+#endif
+{
+  int r = 0;
+
+#ifdef WIN32
+  SetErrorMode( SEM_FAILCRITICALERRORS | SEM_NOOPENFILEERRORBOX );
+#endif
+
+#ifdef GEKKO
+  fatInitDefault();
+#endif
+
+  if( fuse_init( argc, argv ) ) {
+    fprintf( stderr, "%s: error initialising -- giving up!\n", fuse_progname );
+    return 1;
+  }
+
+  if( settings_current.show_help ||
+      settings_current.show_version ) return 0;
+
+  if( settings_current.unittests ) {
+    r = unittests_run();
+  } else {
+    while( !fuse_exiting ) {
+      spectrum_do_frame();
+    }
+    r = debugger_get_exit_code();
+  }
+
+  fuse_end();
+
+  return r;
+}

--- a/settings-win32.pl
+++ b/settings-win32.pl
@@ -30,7 +30,7 @@ sub hashline ($) { '#line ', $_[0] + 1, '"', __FILE__, "\"\n" }
 
 my %options;
 
-my %command_line_only = ( 'gdbserver_wait' => 1 );
+my %command_line_only = ( 'gdbserver_wait' => 1, 'rom_dir' => 1 );
 
 while(<>) {
 

--- a/settings.dat
+++ b/settings.dat
@@ -233,6 +233,8 @@ start_scaler_mode, string, "2x",, 'g', graphics-filter
 
 speccyboot_tap, string, "tap0",
 
+rom_dir, string, NULL
+
 rom_16_0, string, "48.rom",
 rom_48_0, string, "48.rom",
 rom_128_0, string, "128-0.rom",

--- a/settings.pl
+++ b/settings.pl
@@ -55,7 +55,7 @@ my %fileAssoc = ( 'snapshot' => 1, 'tape_file' => 1, 'record_file' => 1,
                   'zxcf_pri_file' => 1,
                   'plus3disk_file' => 1, 'betadisk_file' => 1 );
 
-my %command_line_only = ( 'gdbserver_wait' => 1 );
+my %command_line_only = ( 'gdbserver_wait' => 1, 'rom_dir' => 1 );
 
 while(<>) {
 

--- a/ui/null/Makefile.am
+++ b/ui/null/Makefile.am
@@ -25,6 +25,16 @@ fuse_SOURCES += $(ui_null_files)
 
 BUILT_SOURCES += $(ui_null_built)
 
+all-local: @FUSEX_LIB@
+
+@FUSEX_LIB@: fuse$(EXEEXT)
+	$(AM_V_GEN)objects=`echo " $(fuse_OBJECTS) " | sed 's| main\.$(OBJEXT) | |g'`; \
+	libraries=`echo " $(fuse_LDADD) " | sed 's| -lspectrum | |g'`; \
+	$(CCLD) @FUSEX_LDFLAGS@ $(LDFLAGS) -o $@ $$objects $$libraries \
+	  @LIBSPECTRUM_ARCHIVE@ @LIBSPECTRUM_PRIVATE_LIBS@ $(LIBS)
+
+CLEANFILES += @FUSEX_LIB@
+
 endif
 
 CLEANFILES += $(ui_null_built)

--- a/utils.c
+++ b/utils.c
@@ -314,6 +314,13 @@ utils_find_file_path( const char *filename, char *ret_path,
     return 0;
   }
 
+  if( type == UTILS_AUXILIARY_ROM && settings_current.rom_dir ) {
+    int bytes_written = snprintf( ret_path, PATH_MAX,
+                                  "%s" FUSE_DIR_SEP_STR "%s",
+                                  settings_current.rom_dir, filename );
+    if( bytes_written < PATH_MAX && compat_file_exists( ret_path ) ) return 0;
+  }
+
   /* Otherwise look in some likely locations */
   init_path_context( &ctx, type );
 


### PR DESCRIPTION
This PR adds `libfusex` — the emulator core linked as a shared library. This way, a host process can load it and drive a ZX Spectrum in-process. For example, another program can play a computer game in the emulator.

For now, the library introduces no API of its own, so its capabilities are rudimentary. For example, `display_getpixel()` returns one pixel at a time. The exact shape of the API to be exposed via the library is TBD.

The commits, in order:

### 1. Add `--rom-dir` to name the ROM directory

Fuse looks for a ROM image in the current directory and a few other hard-coded places. That makes it hard for a process using the library to point Fuse at the ROMs.

`--rom-dir <dir>` is added to let the library consumer point to the ROM images explicitly. It is command-line only, so it is never written back to `fuserc`.

### 2. Move the executable entry point to main.c

A shared library must not carry a `main()`, so the entry point moves out of `fuse.c` into its own file.

### 3. Build libfusex

The build produces the shared library file.

## How a host uses it

The host supplies the library it loads and the ROM directory it names.

```python
import ctypes

lib = ctypes.CDLL("/path/to/libfusex.so")
lib.readbyte.argtypes = [ctypes.c_uint16]
lib.readbyte.restype = ctypes.c_uint8

argv = (ctypes.c_char_p * 6)(
    b"fusex", b"--machine", b"48",
    b"--rom-dir", b"/path/to/roms", b"--no-banner",
)
lib.fuse_init(6, argv)

# your code goes here

lib.fuse_end()
```

See `.github/scripts/libfusex_boot_test.py` for a complete example.